### PR TITLE
script to create SEAS5 empirical RP thresholds parquet on blob

### DIFF
--- a/.github/workflows/seas5_monitor.yaml
+++ b/.github/workflows/seas5_monitor.yaml
@@ -1,0 +1,61 @@
+# This workflow uses actions to automatically run SEAS5 analysis
+
+name: SEAS5 Monitor
+
+on:
+  workflow_dispatch:
+      inputs:
+        TEST_EMAIL:
+          required: true
+          type: choice
+          default: "TRUE"
+          options:
+            - "TRUE"
+            - "FALSE"
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      DS_AWS_EMAIL_USERNAME: ${{ secrets.DS_AWS_EMAIL_USERNAME }}
+      DS_AWS_EMAIL_PASSWORD: ${{ secrets.DS_AWS_EMAIL_PASSWORD }}
+      DS_AWS_EMAIL_HOST: ${{ secrets.DS_AWS_EMAIL_HOST }}
+      DS_AWS_EMAIL_PORT: ${{ secrets.DS_AWS_EMAIL_PORT }}
+      DS_AZ_BLOB_PROD_SAS: ${{ secrets.DS_AZ_BLOB_PROD_SAS}}
+      DS_AZ_DB_PROD_PW: ${{ secrets.DS_AZ_DB_PROD_PW}}
+      DS_AZ_DB_PROD_UID: ${{ secrets.DS_AZ_DB_PROD_UID}}
+      TEST_EMAIL: ${{ inputs.TEST_EMAIL || 'FALSE' }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.x'
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libxml2-dev \
+            libgdal-dev \
+            libproj-dev \
+            libgeos-dev \
+            libudunits2-dev \
+            libsodium-dev
+
+      - name: Cache R dependencies
+        id: cache-r-deps
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: R-dependency-cache-${{ hashFiles('.github/depends.R') }}
+
+      - name: Install R dependencies
+        if: steps.cache-r-deps.outputs.cache-hit != 'true'
+        run: |
+          Rscript .github/.depends.R
+
+      - name: R script - Run seas5
+        shell: bash
+        run: Rscript ./src/01_seas5.R

--- a/R/seas5_utils.R
+++ b/R/seas5_utils.R
@@ -1,0 +1,33 @@
+box::use(
+  dplyr,
+  lubridate,
+  glue
+)
+
+#' @export
+aggregate_forecast <-  function(df,valid_months=c(3,4,5), by = c("iso3", "pcode","issued_date")){
+  soi <- glue$glue_collapse(lubridate$month(valid_months,abbr=T,label =T),sep = "-")
+  df |>
+    dplyr$group_by(dplyr$across(dplyr$all_of(by))) |>
+    dplyr$filter(
+      lubridate$month(valid_date) %in% valid_months,
+      all(valid_months %in% lubridate$month(valid_date))
+
+    ) |>
+    dplyr$summarise(
+      mm = sum(precipitation),
+      # **min() - BECAUSE**  for MJJA (5,6,7,8) at each pub_date we have a set of leadtimes
+      # for EXAMPLE in March we have the following leadtimes 2
+      # 2 : March + 2 = May,
+      # 3 : March + 3 = June,
+      # 4 : March + 4 = July
+      # 5:  March + 5 = Aug
+      # Therefore when we sum those leadtime precip values we take min() of lt integer so we get the leadtime to first month being aggregated
+      leadtime = min(leadtime),
+      .groups = "drop"
+    ) |>
+    dplyr$arrange(issued_date) |>
+    dplyr$mutate(
+      valid_month_label = soi
+    )
+}

--- a/data-raw/11_seas5_empirical_rp_thresholds.R
+++ b/data-raw/11_seas5_empirical_rp_thresholds.R
@@ -47,7 +47,7 @@ df_adm1_labels <- tbl(con,"polygon") |>
 
 df_adm1_labels_aoi <- df_adm1_labels |>
   filter(
-    name %in% aoi_adm1
+    name %in% AOI_ADM1
   ) |>
   rename(
     adm1_name =name

--- a/data-raw/11_seas5_empirical_rp_thresholds.R
+++ b/data-raw/11_seas5_empirical_rp_thresholds.R
@@ -1,0 +1,114 @@
+#' @title: Calculate SEAS5 empirical RP-thresholds
+#' Script calculates empirical return period based threshold from SEAS5 data
+#' by publication/issued month & leadtime for the 5 admins under consideration
+#' Afghanistan drought AA.
+
+#' @note
+#' you will want to `devtools::install_github("OCHA-DAP/cumulus")`
+
+box::use(
+  DBI,
+  RPostgres,
+  cumulus,
+  dplyr[...],
+  purrr[...],
+  lubridate[...],
+  seas5 = ../R/seas5_utils
+)
+
+SEASON_OF_INTEREST <- c(3,4,5)
+AOI_ADM1 <- c(
+  "Takhar",
+  "Badakhshan",
+  "Badghis",
+  "Sar-e-Pul" ,
+  "Faryab"
+)
+
+
+con <- DBI$dbConnect(
+  drv = RPostgres$Postgres(),
+  user = Sys.getenv("DS_AZ_DB_PROD_UID_WRITE"),
+  host = Sys.getenv("DS_AZ_DB_PROD_HOST"),
+  password = Sys.getenv("DS_AZ_DB_PROD_PW_WRITE"),
+  port = 5432,
+  dbname = "postgres"
+)
+
+df_adm1_labels <- tbl(con,"polygon") |>
+  filter(
+    iso3 == "AFG",
+    adm_level == 1
+  ) |>
+  select(
+    iso3, pcode, name
+  ) |>
+  collect()
+
+df_adm1_labels_aoi <- df_adm1_labels |>
+  filter(
+    name %in% aoi_adm1
+  ) |>
+  rename(
+    adm1_name =name
+  )
+
+df_seas5_aoi <- tbl(con, "seas5") |>
+  filter(
+    iso3 == "AFG",
+    adm_level ==1,
+    pcode %in%  df_adm1_labels_aoi$pcode
+  ) |>
+  collect() |>
+  mutate(
+    precipitation = mean * days_in_month(valid_date)
+  )
+
+
+df_seas5_mam <- seas5$aggregate_forecast(
+  df_seas5_aoi,
+  valid_months = SEASON_OF_INTEREST,
+  by = c("iso3","pcode","issued_date")
+)
+
+df_seas5_rps_historical <- df_seas5_mam |>
+  mutate(
+    pub_mo = month(issued_date,label =T, abbr=T)
+  ) |>
+  group_by(iso3, pcode, pub_mo, leadtime) |>
+  arrange(
+    pcode,pub_mo,mm
+  ) |>
+  mutate(
+    rank = row_number(),
+    q_rank = rank/(max(rank)+1),
+    rp_emp = 1/q_rank,
+
+  ) |>
+  arrange(pcode,pub_mo,mm) |>
+  ungroup()
+
+
+
+df_seas5_rp_rv <- df_seas5_rps_historical |>
+  group_by(iso3, pcode, pub_mo, leadtime) |>
+  reframe(
+    rp_func = list(approxfun( rp_emp, mm,rule=2)), #interpolation function
+    rp = 2:7, # calculate for RPs 2-7 - should give sufficient options
+    rv = map_dbl(rp, rp_func)
+  ) |>
+  select(-rp_func) |>
+  left_join(df_adm1_labels_aoi, by = c("iso3","pcode")) |>
+  mutate(
+    # tagging on a few columns in case i want to start compiling a thresholds
+    # table with more indicators in future.
+    parameter = "SEAS5 - MAM Forecast",
+    rp_type = "Empirical"
+  )
+
+cumulus$blob_write(
+  df = df_seas5_rp_rv,
+  name = "ds-aa-afg-drought/processed/vector/afg_SEAS5_thresholds.parquet",
+  stage = "dev",
+  container = "projects"
+)


### PR DESCRIPTION
simple script to calculate empirical RP based thresholds for seas5 and store them in table in blob. These will be used for initial monitoring.

Might add model-based RP calcs at some later point, but figure good to get this approved and going anyways.

Suggest we merge this in before reviewing `indicator-expansion` PR