### PR TITLE
some adhoc checks and visualizations after april activation moment

### DIFF
--- a/book_afg_analysis/07_pre_season_allocation_options.qmd
+++ b/book_afg_analysis/07_pre_season_allocation_options.qmd
@@ -792,7 +792,7 @@ df_cerf <- cumulus::blob_read("ds-aa-afg-drought/raw/vector/afg_drought_cerf_all
 
 # if you do play around w/ this number it does look like it peaks out around 4... which equate to a joint RP of around 3
 # w/ rp at 5 u miss 2006 activatoin
-rp_compare <- 4
+rp_compare <- 5.2
 
 df_asi_eos_full <- df_fao |>
   clean_names() |>

--- a/book_afg_analysis/09_create_cdi_thresholds.qmd
+++ b/book_afg_analysis/09_create_cdi_thresholds.qmd
@@ -168,6 +168,27 @@ df_cdi_thresholds<- df_cdi_historical_rp_flagged |>
   select(-rp_func)
 ```
 
+```{r}
+#| eval: false
+
+
+z_score_sar <- -0.0260
+z_score_takhar <- -0.0583
+z_score_faryab <- 0.64
+# z_score_faryab <- 0.56
+df_cdi_historical_rp_flagged |>
+  group_by(adm1_name, pub_mo_label) |>
+  reframe(
+    # interpolating just a bit to get 5.2 value agreed upon as the
+    # value in the data is closer to 5.25
+    rp_func = list(approxfun( cdi, rp_empirical,rule=2)), #interpolation function
+    rv1 = z_score_sar,
+    RP = map_dbl(rv1, rp_func)
+  ) |>
+  select(-rp_func)
+```
+
+
 Then we calculate the overall RP for window B (i.e any provnce activating).
 
 ```{r}

--- a/src/trigger_monitoring/R_monitoring/wranglers.R
+++ b/src/trigger_monitoring/R_monitoring/wranglers.R
@@ -35,6 +35,7 @@ aggregate_mixed_fcast_obs <-  function(df_fcast, df_observed){
     )
 }
 
+#'@export
 compile_mixed_fcast_obs_table <- function(df_fcast, df_observed){
   df_params  <- mload$load_mixed_fcast_obs_params()
   df_params_era5 <- df_params$era5 |>


### PR DESCRIPTION
after merging `monitoring-2025` branch did some one-off checks and table to better visualize drivers and output of april activation monitoring. Just going to go ahead and merge this for the sake of not leaving it hanging. its non-consequential to any results