### PR TITLE
Add W1 SEAS5 monitoring with Listmonk email notifications

### DIFF
--- a/.github/workflows/w1_seas5_monitor.yaml
+++ b/.github/workflows/w1_seas5_monitor.yaml
@@ -1,0 +1,53 @@
+# Window 1 SEAS5 MAM forecast monitoring for 2026 drought trigger
+#
+# Reads SEAS5 from prod postgres, thresholds + area weights from dev blob.
+# Uploads plot + JSON summary to dev blob.
+# Sends email notification via Listmonk.
+
+name: SEAS5 W1 Monitor (2026)
+
+on:
+  schedule:
+    # Run March 5 at 06:00 UTC — SEAS5 March forecast typically available
+    # by first few days of the month
+    - cron: "0 6 5 3 *"
+  workflow_dispatch:
+    inputs:
+      year:
+        description: "Forecast year to evaluate (default: current year)"
+        required: false
+        type: string
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    env:
+      DSCI_AZ_DB_PROD_PW: ${{ secrets.DSCI_AZ_DB_PROD_PW }}
+      DSCI_AZ_DB_PROD_UID: ${{ secrets.DSCI_AZ_DB_PROD_UID }}
+      DSCI_AZ_DB_PROD_HOST: ${{ secrets.DSCI_AZ_DB_PROD_HOST }}
+      DSCI_AZ_BLOB_DEV_SAS: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS }}
+      DSCI_AZ_BLOB_DEV_SAS_WRITE: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS_WRITE }}
+      DSCI_LISTMONK_API_USERNAME: ${{ vars.DSCI_LISTMONK_API_USERNAME }}
+      DSCI_LISTMONK_API_KEY: ${{ secrets.DSCI_LISTMONK_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python and install dependencies
+        run: uv sync
+
+      - name: Determine year
+        id: params
+        run: |
+          if [ -n "${{ inputs.year }}" ]; then
+            echo "year=${{ inputs.year }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "year=$(date +%Y)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run SEAS5 W1 monitoring
+        run: |
+          uv run python src/monitoring_2026/w1_monitor_seas5.py \
+            --year ${{ steps.params.outputs.year }}

--- a/.github/workflows/w1_seas5_monitor.yaml
+++ b/.github/workflows/w1_seas5_monitor.yaml
@@ -17,6 +17,11 @@ on:
         description: "Forecast year to evaluate (default: current year)"
         required: false
         type: string
+      test:
+        description: "Add [test] prefix to email subject"
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   monitor:
@@ -49,5 +54,6 @@ jobs:
 
       - name: Run SEAS5 W1 monitoring
         run: |
-          uv run python src/monitoring_2026/w1_monitor_seas5.py \
-            --year ${{ steps.params.outputs.year }}
+          uv run python src/monitoring_2026/w1_monitor_seas5_transactional.py \
+            --year ${{ steps.params.outputs.year }} \
+            ${{ inputs.test == true && '--test' || '' }}

--- a/.github/workflows/w1_seas5_monitor.yaml
+++ b/.github/workflows/w1_seas5_monitor.yaml
@@ -22,6 +22,16 @@ on:
         required: false
         type: boolean
         default: true
+      email_group:
+        description: "Distribution list group"
+        required: false
+        type: choice
+        default: core_developer
+        options:
+          - core_developer
+          - developers
+          - internal_chd
+          - full_list
 
 jobs:
   monitor:
@@ -56,4 +66,5 @@ jobs:
         run: |
           uv run python src/monitoring_2026/w1_monitor_seas5_transactional.py \
             --year ${{ steps.params.outputs.year }} \
+            --email-group ${{ inputs.email_group || 'core_developer' }} \
             ${{ inputs.test == true && '--test' || '' }}

--- a/.github/workflows/w1_seas5_monitor.yaml
+++ b/.github/workflows/w1_seas5_monitor.yaml
@@ -7,10 +7,10 @@
 name: SEAS5 W1 Monitor (2026)
 
 on:
-  schedule:
-    # Run March 5 at 06:00 UTC — SEAS5 March forecast typically available
-    # by first few days of the month
-    - cron: "0 6 5 3 *"
+  # schedule:
+  #   # Run March 5 at 06:00 UTC — SEAS5 March forecast typically available
+  #   # by first few days of the month
+  #   - cron: "0 6 5 3 *"
   workflow_dispatch:
     inputs:
       year:

--- a/.gitignore
+++ b/.gitignore
@@ -209,6 +209,7 @@ book_afg_analysis/_freeze/*
 
 dash_explore/*
 outputs/*
+src/monitoring_2026/outputs/
 
 *.ipynb
 .idea/*

--- a/book_afg_analysis/.gitignore
+++ b/book_afg_analysis/.gitignore
@@ -1,1 +1,3 @@
 /.quarto/
+
+**/*.quarto_ipynb

--- a/book_afg_analysis/08_weight_selection.qmd
+++ b/book_afg_analysis/08_weight_selection.qmd
@@ -17,9 +17,9 @@ execute:
   out.width: "100%"
 jupyter:
   kernelspec:
-    name: "dsci_playground"
+    name: "ds-aa-afg-drought"
     language: "python"
-    display_name: "dsci_playground"
+    display_name: "ds-aa-afg-drought"
 project:
   execute-dir: project
 ---

--- a/book_afg_analysis/12_2026_trigger_modeling.qmd
+++ b/book_afg_analysis/12_2026_trigger_modeling.qmd
@@ -43,6 +43,8 @@ box::use(
     purrr[...],
     glue[glue],
     tibble[tibble],
+    ggfx[with_outer_glow],
+    ggrepel[geom_text_repel],
     .. / R / utils[rp_empirical]
 )
 
@@ -933,43 +935,146 @@ ggplot(df_apr_cdi, aes(x = year, y = CDI)) +
 ### Component Contributions
 
 ```{r}
-#| label: cdi-components
-#| fig-height: 7
+#| label: fig-cdi-components
+#| fig-cap: "CDI Components and Weighted Index"
+#| fig-height: 6
 #| fig-width: 10
 
-weight_labels <- cdi_weights |>
-    mutate(label = paste0(term, " (", round(weight * 100, 0), "%)")) |>
-    select(term, label)
+# Color palette matching monitoring plot style
+pal_components <- c(
+    "CDI" = "black",
+    "VHI" = "#CCEBC5",
+    "MAM precip (mixed obs forecast)" = "#DECBE4",
+    "Snow Cover" = "#FFFF90",
+    "ASI" = "#FBB4AE",
+    "Soil moisture" = "#fec44f"
+)
+
+# Map component names to nice labels
+component_label_map <- c(
+    "vhi" = "VHI",
+    "mixed_fcast_obsv" = "MAM precip (mixed obs forecast)",
+    "snow_cover" = "Snow Cover",
+    "asi" = "ASI",
+    "volumetric_soil_water_1m" = "Soil moisture"
+)
 
 df_components <- df_apr_cdi |>
     select(year, drought, all_of(cdi_weights$term), CDI) |>
     pivot_longer(cols = all_of(cdi_weights$term),
                  names_to = "component", values_to = "zscore") |>
-    left_join(weight_labels, by = c("component" = "term"))
+    mutate(
+        parameter_label = component_label_map[component],
+        parameter_label = factor(parameter_label, levels = names(pal_components))
+    )
 
-ggplot() +
-    geom_line(data = df_components,
-              aes(x = year, y = zscore, color = label),
-              alpha = 0.6, linewidth = 0.7) +
-    geom_line(data = df_apr_cdi, aes(x = year, y = CDI),
-              color = "black", linewidth = 1.5) +
-    geom_hline(yintercept = cdi_threshold, linetype = "dashed", color = "red") +
-    geom_point(data = df_apr_cdi |> filter(drought == "yes"),
-               aes(x = year, y = CDI), color = "red", size = 3) +
-    scale_color_brewer(palette = "Set2") +
-    labs(
-        title = "CDI Components and Weighted Index",
-        subtitle = "Black = CDI | Red dots = drought years | Colored = components",
-        x = "Year", y = "Z-score / CDI", color = "Component"
+# CDI data for separate layer
+df_cdi_line <- df_apr_cdi |>
+    mutate(parameter_label = "CDI")
+
+# Drought years for points and labels
+df_drought_years <- df_apr_cdi |>
+    filter(drought == "yes")
+
+p_cdi_components <- ggplot() +
+    # Component lines with shadow
+    ggfx::with_shadow(
+        geom_line(
+            data = df_components,
+            aes(x = year, y = zscore, color = parameter_label, group = parameter_label),
+            alpha = 1, linewidth = 0.5
+        ),
+        sigma = 1.0, x_offset = 0.5, y_offset = 0.25
     ) +
-    theme(legend.position = "bottom") +
-    guides(color = guide_legend(nrow = 2))
+    # Threshold line
+    geom_hline(
+        yintercept = cdi_threshold,
+        color = hdx_hex("tomato-dark"),
+        linetype = "dashed", linewidth = 0.5
+    ) +
+    # CDI line with shadow (on top)
+    ggfx::with_shadow(
+        geom_line(
+            data = df_cdi_line,
+            aes(x = year, y = CDI),
+            color = "black", linewidth = 1
+        ),
+        sigma = 2, x_offset = 0.5, y_offset = 0.25
+    ) +
+    # Drought year points
+    geom_point(
+        data = df_drought_years,
+        aes(x = year, y = CDI),
+        color = hdx_hex("tomato-hdx"),
+        size = 2.5, alpha = 0.7
+    ) +
+    # Threshold label
+    geom_label(
+        aes(x = 1990, y = cdi_threshold,
+            label = paste0("Threshold: ", round(cdi_threshold, 2))),
+        vjust = -0.3, hjust = 0,
+        color = hdx_hex("tomato-dark"),
+        size = 4, alpha = 0.5,
+        label.padding = unit(0.15, "cm")
+    ) +
+    # Year labels for drought years
+    geom_text_repel(
+        data = df_drought_years,
+        aes(x = year, y = CDI, label = year),
+        color = hdx_hex("tomato-hdx"),
+        vjust = -2, size = 3.5, alpha = 1
+    ) +
+    # Scales
+    scale_color_manual(values = pal_components, drop = FALSE, name = NULL) +
+    scale_x_continuous(
+        breaks = seq(1985, 2025, by = 5),
+        expand = expansion(mult = c(0.01, 0.03))
+    ) +
+    # Labels
+    labs(
+        title = "Drought AA Afghanistan: 2026 April Trigger",
+        subtitle = "Red dashed line represents RP 4 threshold",
+        x = NULL,
+        y = "Indicator anomaly"
+    ) +
+    theme(
+        axis.title.x = element_blank(),
+        axis.title.y = element_text(size = 14),
+        title = element_text(size = 16),
+        legend.key.width = unit(1, "cm"),
+        plot.subtitle = element_text(size = 14, color = "grey40"),
+        legend.title = element_blank(),
+        legend.text = element_text(size = 12),
+        legend.position = "bottom",
+        axis.text.y = element_text(angle = 90, size = 10, hjust = 0.5),
+        axis.text.x = element_text(size = 10),
+        panel.grid.minor = element_blank(),
+        panel.grid.major.x = element_blank()
+    ) +
+    guides(color = guide_legend(nrow = 1, override.aes = list(linewidth = 2)))
+
+ggsave("outputs/figures/fig-cdi-components.png", p_cdi_components, width = 10, height = 6, dpi = 300)
+
+# Paper version with larger text
+p_cdi_components_paper <- p_cdi_components +
+    theme(
+        axis.title.y = element_text(size = 16),
+        title = element_text(size = 18),
+        plot.subtitle = element_text(size = 16, color = "grey40"),
+        legend.text = element_text(size = 14),
+        axis.text.y = element_text(angle = 90, size = 12, hjust = 0.5),
+        axis.text.x = element_text(size = 12)
+    )
+ggsave("outputs/figures/paper/fig-cdi-components.png", p_cdi_components_paper, width = 10, height = 6, dpi = 300)
+
+p_cdi_components
 ```
 
 ### Year-by-Year Trigger Decisions
 
 ```{r}
-#| label: trigger-table
+#| label: tbl-trigger-comparison
+#| tbl-cap: "Trigger Comparison: April Window (All Years)"
 
 library(gt)
 
@@ -1118,6 +1223,78 @@ The critical difference is **confidence in the estimates**:
 | Degrees of freedom | ~200,000 combinations tested | ~10 hyperparameters |
 | Overfitting risk | High | Low (regularized) |
 | Generalization | Uncertain | More reliable |
+
+### Weight Comparison
+
+```{r}
+#| label: weight-comparison-stacked
+#| fig-height: 5
+#| fig-width: 7
+
+# 2025 weights (from design_weights() / weight set 11209)
+df_weights_2025 <- tibble(
+    indicator = c("Snow Cover", "Precip Cumsum", "Soil Moisture",
+                  "MAM Precip (mixed)", "ASI", "VHI"),
+    weight = c(0.15, 0.05, 0.05, 0.25, 0.25, 0.25),
+    model = "2025"
+)
+
+# 2026 weights from ridge regression (live from cdi_weights)
+indicator_label_map <- c(
+    "vhi" = "VHI",
+    "mixed_fcast_obsv" = "MAM Precip (mixed)",
+    "snow_cover" = "Snow Cover",
+    "asi" = "ASI",
+    "volumetric_soil_water_1m" = "Soil Moisture"
+)
+
+df_weights_2026 <- cdi_weights |>
+    mutate(
+        indicator = indicator_label_map[term],
+        model = "2026"
+    ) |>
+    select(indicator, weight, model)
+
+# Combine
+df_weights_all <- bind_rows(df_weights_2025, df_weights_2026) |>
+    mutate(
+        indicator = factor(indicator, levels = c(
+            "VHI", "ASI", "MAM Precip (mixed)",
+            "Snow Cover", "Soil Moisture", "Precip Cumsum"
+        )),
+        pct_label = paste0(round(weight * 100, 0), "%")
+    )
+
+pal_indicators <- c(
+    "VHI" = "#CCEBC5",
+    "ASI" = "#FBB4AE",
+    "MAM Precip (mixed)" = "#DECBE4",
+    "Snow Cover" = "#FFFF90",
+    "Soil Moisture" = "#fec44f",
+    "Precip Cumsum" = "#B3CDE3"
+)
+
+ggplot(df_weights_all, aes(x = model, y = weight, fill = indicator)) +
+    geom_col(width = 0.6, color = "grey30", linewidth = 0.3) +
+    geom_text(
+        aes(label = pct_label),
+        position = position_stack(vjust = 0.5),
+        size = 3.5, fontface = "bold"
+    ) +
+    scale_fill_manual(values = pal_indicators, drop = FALSE) +
+    scale_y_continuous(labels = scales::percent, expand = c(0, 0)) +
+    labs(
+        title = "CDI Component Weights: 2025 vs 2026",
+        subtitle = "2025: grid search | 2026: ridge regression",
+        x = NULL, y = "Weight", fill = "Indicator"
+    ) +
+    theme(
+        legend.position = "right",
+        panel.grid.major.x = element_blank()
+    )
+```
+
+The 2026 model drops `precip_cumsum` (redundant with other precipitation indicators — see [Appendix F](#appendix-f-cumulative-precip)) and redistributes weight toward soil moisture and snow cover. The precipitation composite and VHI/ASI remain the dominant contributors in both years.
 
 ::: {.callout-note}
 ## Bottom Line
@@ -1644,3 +1821,267 @@ This is a meaningful quantity, but:
 
 The CDI is mathematically equivalent to the ridge model's linear predictor (r = 1) and produces identical year rankings as the predicted probability. We tune the probability threshold to maximize F1, then derive the equivalent CDI cutoff — both produce identical trigger decisions. The F1-optimized threshold corresponds to approximately RP 3.9 (close to the policy target of RP 4). CDI is preferred operationally for its interpretability; probability would be appropriate if partners requested probabilistic risk communication.
 :::
+
+---
+
+## Appendix F: Including Cumulative Precipitation {#appendix-f-cumulative-precip}
+
+The 2025 trigger included cumulative precipitation (`precip_cumsum`) as one of the six CDI components. In the main 2026 model above, we excluded it due to collinearity concerns with other precipitation-related variables. This appendix tests whether including it improves model performance.
+
+### Model with All 2025 Variables
+
+We fit a ridge model including `precip_cumsum` alongside the other indicators, matching the 2025 variable set (except using the composite `mixed_fcast_obsv` instead of individual forecast months).
+
+```{r}
+#| label: appendix-f-ridge-with-precip
+
+# Ridge model INCLUDING precip_cumsum
+ridge_recipe_precip <- recipe(drought ~ ., data = df_apr) |>
+    step_rm(all_of(c("pub_year", APRIL_EXCLUDE_VARS))) |>  # Note: NOT removing precip_cumsum
+    step_zv(all_predictors())
+
+ridge_wf_precip <- workflow() |>
+    add_recipe(ridge_recipe_precip) |>
+    add_model(ridge_spec)
+
+# Bootstrap resampling with penalty tuning
+set.seed(SEED)
+ridge_boots_precip <- bootstraps(df_apr, times = N_BOOTSTRAP, strata = drought)
+
+ridge_tune_precip <- tune_grid(
+    ridge_wf_precip,
+    resamples = ridge_boots_precip,
+    grid = penalty_grid,
+    metrics = metric_set(roc_auc, f_meas, precision, recall),
+    control = control_grid(save_pred = TRUE)
+)
+
+# Select best penalty
+best_penalty_precip <- select_best(ridge_tune_precip, metric = "f_meas")
+final_ridge_fit_precip <- fit(
+    ridge_wf_precip |> finalize_workflow(best_penalty_precip),
+    data = df_apr
+)
+
+# Extract coefficients
+coefs_ridge_precip <- final_ridge_fit_precip |>
+    extract_fit_parsnip() |>
+    tidy() |>
+    filter(term != "(Intercept)")
+
+cdi_weights_precip <- coefs_ridge_precip |>
+    mutate(
+        weight = -estimate / sum(abs(estimate)),
+        contribution_pct = abs(weight) * 100
+    ) |>
+    arrange(desc(contribution_pct)) |>
+    select(term, estimate, weight, contribution_pct)
+```
+
+### CDI Weights with Cumulative Precipitation
+
+```{r}
+#| label: appendix-f-weights-table
+
+cdi_weights_precip |>
+    knitr::kable(
+        digits = 3,
+        col.names = c("Indicator", "Ridge Coef", "CDI Weight", "Contribution %"),
+        caption = "CDI weights including cumulative precipitation"
+    )
+```
+
+### LOOCV Performance Comparison
+
+```{r}
+#| label: appendix-f-loocv
+
+# LOOCV for model with precip_cumsum
+loocv_precip_results <- map_dfr(1:nrow(df_apr), function(i) {
+    train <- df_apr[-i, ]
+    test <- df_apr[i, ]
+
+    rec <- recipe(drought ~ ., data = train) |>
+        step_rm(all_of(c("pub_year", APRIL_EXCLUDE_VARS))) |>
+        step_zv(all_predictors())
+
+    spec <- logistic_reg(penalty = best_penalty_precip$penalty, mixture = 0) |>
+        set_engine("glmnet") |>
+        set_mode("classification")
+
+    wf <- workflow() |>
+        add_recipe(rec) |>
+        add_model(spec)
+
+    fit_result <- fit(wf, data = train)
+
+    # Get probability for ROC AUC
+    prob <- predict(fit_result, test, type = "prob")$.pred_yes
+
+    # CDI-based trigger
+    coefs <- fit_result |>
+        extract_fit_parsnip() |>
+        tidy() |>
+        filter(term != "(Intercept)") |>
+        mutate(weight = -estimate / sum(abs(estimate)))
+
+    train_cdi <- rep(0, nrow(train))
+    for (j in seq_len(nrow(coefs))) {
+        feat <- coefs$term[j]
+        w <- coefs$weight[j]
+        if (feat %in% colnames(train)) {
+            train_cdi <- train_cdi + w * train[[feat]]
+        }
+    }
+    train_rp <- rp_empirical(train_cdi, direction = "-1")
+    threshold <- min(train_cdi[train_rp >= RP_THRESHOLD])
+
+    test_cdi <- 0
+    for (j in seq_len(nrow(coefs))) {
+        feat <- coefs$term[j]
+        w <- coefs$weight[j]
+        if (feat %in% colnames(test)) {
+            test_cdi <- test_cdi + w * test[[feat]]
+        }
+    }
+
+    tibble(
+        year = test$pub_year,
+        actual = test$drought,
+        prob = prob,
+        predicted = if_else(test_cdi >= threshold, "yes", "no")
+    )
+})
+
+# Confusion matrix
+loocv_precip_conf <- table(
+    Predicted = factor(loocv_precip_results$predicted, levels = c("yes", "no")),
+    Actual = factor(loocv_precip_results$actual, levels = c("yes", "no"))
+)
+
+tp_precip <- loocv_precip_conf["yes", "yes"]
+fp_precip <- loocv_precip_conf["yes", "no"]
+fn_precip <- loocv_precip_conf["no", "yes"]
+```
+
+```{r}
+#| label: appendix-f-comparison
+
+# Comparison table
+tibble(
+    Model = c("Without precip_cumsum (main)", "With precip_cumsum"),
+    `N Features` = c(nrow(cdi_weights), nrow(cdi_weights_precip)),
+    `ROC AUC` = c(
+        round(yardstick::roc_auc_vec(loocv_composite_probs$actual, loocv_composite_probs$prob), 3),
+        round(yardstick::roc_auc_vec(loocv_precip_results$actual, loocv_precip_results$prob), 3)
+    ),
+    Precision = c(
+        round(tp_ridge_loo / (tp_ridge_loo + fp_ridge_loo), 3),
+        round(tp_precip / (tp_precip + fp_precip), 3)
+    ),
+    Recall = c(
+        round(tp_ridge_loo / (tp_ridge_loo + fn_ridge_loo), 3),
+        round(tp_precip / (tp_precip + fn_precip), 3)
+    ),
+    F1 = c(
+        round(2 * tp_ridge_loo / (2 * tp_ridge_loo + fp_ridge_loo + fn_ridge_loo), 3),
+        round(2 * tp_precip / (2 * tp_precip + fp_precip + fn_precip), 3)
+    )
+) |>
+    knitr::kable(caption = "LOOCV comparison: With vs without cumulative precipitation")
+```
+
+### LOOCV Confusion Matrices
+
+```{r}
+#| label: appendix-f-confusion
+
+cat("Without precip_cumsum (main model):\n")
+loocv_ridge_conf |>
+    as.data.frame.matrix() |>
+    knitr::kable()
+
+cat("\nWith precip_cumsum:\n")
+loocv_precip_conf |>
+    as.data.frame.matrix() |>
+    knitr::kable()
+```
+
+### Weight Comparison
+
+How does including cumulative precipitation change the weights assigned to other components?
+
+```{r}
+#| label: appendix-f-weight-comparison
+#| fig-height: 5
+#| fig-width: 8
+
+# Combine weights for comparison
+df_weight_compare <- bind_rows(
+    cdi_weights |> mutate(model = "Without precip_cumsum"),
+    cdi_weights_precip |> mutate(model = "With precip_cumsum")
+) |>
+    select(model, term, weight, contribution_pct)
+
+df_weight_compare |>
+    ggplot(aes(x = reorder(term, contribution_pct), y = contribution_pct, fill = model)) +
+    geom_col(position = position_dodge(width = 0.8), width = 0.7) +
+    geom_text(
+        aes(label = paste0(round(contribution_pct, 0), "%")),
+        position = position_dodge(width = 0.8),
+        hjust = -0.1, size = 3
+    ) +
+    coord_flip() +
+    scale_fill_manual(values = c("Without precip_cumsum" = "steelblue",
+                                  "With precip_cumsum" = "tomato")) +
+    scale_y_continuous(limits = c(0, 35), expand = c(0, 0)) +
+    labs(
+        title = "CDI Component Weights: With vs Without Cumulative Precipitation",
+        x = NULL, y = "Contribution (%)", fill = "Model"
+    ) +
+    theme(legend.position = "top")
+```
+
+::: {.callout-note}
+## Finding
+
+Including cumulative precipitation (`precip_cumsum`) in the April CDI model produces similar LOOCV performance to the main model without it. The variable receives a weight of approximately `r round(cdi_weights_precip$contribution_pct[cdi_weights_precip$term == "precip_cumsum"], 0)`%, redistributing weight away from the other indicators.
+
+The similar performance suggests that cumulative precipitation provides partially redundant information — its signal is already captured by other indicators (soil moisture, the mixed forecast/observation composite). For operational simplicity, the main 5-component model is preferred.
+:::
+
+### Year-by-Year Comparison
+
+Do the two models trigger on the same years?
+
+```{r}
+#| label: appendix-f-year-comparison
+
+# Merge predictions
+df_year_compare <- loocv_ridge_results |>
+    select(year, actual, predicted_main = predicted) |>
+    left_join(
+        loocv_precip_results |> select(year, predicted_precip = predicted),
+        by = "year"
+    ) |>
+    mutate(
+        agree = predicted_main == predicted_precip,
+        both_correct = predicted_main == actual & predicted_precip == actual,
+        main_only_correct = predicted_main == actual & predicted_precip != actual,
+        precip_only_correct = predicted_precip == actual & predicted_main != actual
+    )
+
+# Summary
+cat("Agreement between models:\n")
+cat("  Same prediction:", sum(df_year_compare$agree), "of", nrow(df_year_compare), "years\n")
+cat("  Disagreements:", sum(!df_year_compare$agree), "years\n\n")
+
+# Show disagreements if any
+if (sum(!df_year_compare$agree) > 0) {
+    cat("Years where models disagree:\n")
+    df_year_compare |>
+        filter(!agree) |>
+        select(year, actual, predicted_main, predicted_precip) |>
+        knitr::kable(col.names = c("Year", "Actual", "Main Model", "With Precip"))
+}
+```

--- a/book_afg_analysis/12_2026_trigger_modeling.qmd
+++ b/book_afg_analysis/12_2026_trigger_modeling.qmd
@@ -42,7 +42,8 @@ box::use(
     cumulus[...],
     purrr[...],
     glue[glue],
-    tibble[tibble]
+    tibble[tibble],
+    .. / R / utils[rp_empirical]
 )
 
 library(tidymodels)
@@ -67,8 +68,11 @@ FEATURE_PATHS <- list(
     april = "ds-aa-afg-drought/processed/vector/2026_april_pub_feature_set_v1.parquet"
 )
 
-# Variables to exclude (use composite instead of individual SEAS5 components)
+# Variables to exclude per model variant
+# Model 1 (Composite): uses mixed_fcast_obsv, excludes individual forecast components
 APRIL_EXCLUDE_VARS <- c("total_precipitation_sum", "seas5 Apr", "seas5 May")
+# Model 2 (Individual components): uses individual months, excludes composite
+APRIL_EXCLUDE_VARS_MODEL2 <- c("mixed_fcast_obsv")
 MARCH_EXCLUDE_VARS <- c()
 ```
 
@@ -630,12 +634,10 @@ df_apr_cdi <- df_apr |>
         year = pub_year
     )
 
-# CDI threshold at RP percentile
-cdi_threshold <- quantile(df_apr_cdi$CDI, 1 - 1 / RP_THRESHOLD)
-
+# CDI empirical RPs (Weibull plotting position) — trigger threshold
+# is derived from F1-optimized probability in the threshold-analysis chunk
 df_apr_cdi <- df_apr_cdi |>
-    mutate(trigger = factor(if_else(CDI >= cdi_threshold, "yes", "no"),
-                            levels = c("yes", "no")))
+    mutate(cdi_rp = rp_empirical(CDI, direction = "-1"))
 ```
 
 ## Threshold Selection
@@ -645,8 +647,8 @@ df_apr_cdi <- df_apr_cdi |>
 Our model outputs continuous values (CDI or predicted probabilities). We need a **threshold** to convert these to yes/no trigger decisions. Three approaches:
 
 1. **Default P > 0.5**: Standard classification threshold
-2. **F1-optimized threshold**: Threshold that maximizes F1 score
-3. **RP-based CDI threshold**: Threshold at the `r RP_THRESHOLD`-year return period percentile
+2. **F1-optimized threshold**: Probability threshold that maximizes F1 score
+3. **CDI (F1-equivalent)**: The CDI value equivalent to the F1-optimized probability threshold, expressed as a Weibull percentile/RP
 
 ```{r}
 #| label: threshold-analysis
@@ -684,12 +686,33 @@ best_prob_threshold <- threshold_results |>
     slice(1) |>
     pull(threshold)
 
+# Derive CDI threshold from F1-optimized probability
+# Since CDI and probability rankings are identical (same model, monotonic transform),
+# the F1-optimized probability maps to a specific CDI cutoff
+n_trigger_tuned <- sum(df_apr_probs$prob_drought > best_prob_threshold)
+cdi_threshold <- min(df_apr_probs$CDI[df_apr_probs$prob_drought > best_prob_threshold])
+
+# Weibull RP and percentile equivalent of the F1-optimized threshold
+rp_f1_equivalent <- round((nrow(df_apr_probs) + 1) / n_trigger_tuned, 2)
+weibull_pctile <- round((1 - n_trigger_tuned / (nrow(df_apr_probs) + 1)) * 100, 1)
+
 df_apr_compare <- df_apr_probs |>
     mutate(
         trigger_tuned = factor(
             if_else(prob_drought > best_prob_threshold, "yes", "no"),
             levels = c("yes", "no")
+        ),
+        trigger = factor(
+            if_else(CDI >= cdi_threshold, "yes", "no"),
+            levels = c("yes", "no")
         )
+    )
+
+# Update df_apr_cdi for downstream use (plots, confusion matrix)
+df_apr_cdi <- df_apr_cdi |>
+    mutate(
+        trigger = factor(if_else(CDI >= cdi_threshold, "yes", "no"),
+                         levels = c("yes", "no"))
     )
 ```
 
@@ -735,9 +758,12 @@ comparison_table <- bind_rows(
     calc_trigger_metrics(df_apr_compare$trigger_default, df_apr_compare$drought) |>
         mutate(approach = "P > 0.5 (default)", threshold = "0.50"),
     calc_trigger_metrics(df_apr_compare$trigger_tuned, df_apr_compare$drought) |>
-        mutate(approach = "P > tuned", threshold = as.character(best_prob_threshold)),
+        mutate(approach = "P > tuned (F1)", threshold = as.character(best_prob_threshold)),
     calc_trigger_metrics(df_apr_compare$trigger, df_apr_compare$drought) |>
-        mutate(approach = "CDI (RP-based)", threshold = paste0(round(cdi_threshold, 2), " (75th %ile)"))
+        mutate(
+            approach = "CDI (F1-equivalent)",
+            threshold = glue("CDI ≥ {round(cdi_threshold, 3)} ({weibull_pctile}th %ile)")
+        )
 ) |>
     select(approach, threshold, precision, recall, f1, n_triggered)
 
@@ -749,14 +775,14 @@ comparison_table |>
     )
 ```
 
-**Ranking equivalence**: Since CDI is derived from the same model, probability and CDI rankings are identical (correlation = `r round(cor(rank(-df_apr_compare$prob_drought), rank(-df_apr_compare$CDI)), 4)`).
+**Ranking equivalence**: Since CDI is derived from the same model, probability and CDI rankings are identical (correlation = `r round(cor(rank(-df_apr_compare$prob_drought), rank(-df_apr_compare$CDI)), 4)`). The F1-optimized probability threshold (P > `r best_prob_threshold`) maps exactly to CDI ≥ `r round(cdi_threshold, 3)` — both trigger `r n_trigger_tuned` years.
 
 ::: {.callout-note}
-## Threshold Convergence
+## Threshold Equivalence
 
-The **F1-optimized threshold** (P > `r best_prob_threshold`) triggers `r sum(df_apr_compare$trigger_tuned == "yes")` of `r nrow(df_apr_compare)` years (`r round(sum(df_apr_compare$trigger_tuned == "yes") / nrow(df_apr_compare) * 100, 0)`%), corresponding to roughly the **`r round((1 - sum(df_apr_compare$trigger_tuned == "yes") / nrow(df_apr_compare)) * 100, 0)`th percentile**.
+The **F1-optimized threshold** (P > `r best_prob_threshold`) triggers `r n_trigger_tuned` of `r nrow(df_apr_compare)` years (`r round(n_trigger_tuned / nrow(df_apr_compare) * 100, 1)`%), corresponding to the **`r weibull_pctile`th percentile** (Weibull plotting position: rank/(n+1)), or equivalently a return period of **`r rp_f1_equivalent` years**.
 
-This closely matches the RP=`r RP_THRESHOLD` policy threshold (75th percentile, ~25% trigger rate). The statistically optimal threshold aligns with the operationally desired trigger frequency - a fortunate convergence that won't always occur.
+This is close to the policy target of RP`r RP_THRESHOLD` (75th percentile). The statistically optimal threshold approximately recovers the operationally desired trigger frequency.
 :::
 
 ## Model Validation (LOOCV)
@@ -804,7 +830,8 @@ loocv_ridge_results <- map_dfr(1:nrow(df_apr), function(i) {
             train_cdi <- train_cdi + w * train[[feat]]
         }
     }
-    threshold <- quantile(train_cdi, 1 - 1 / RP_THRESHOLD)
+    train_rp <- rp_empirical(train_cdi, direction = "-1")
+    threshold <- min(train_cdi[train_rp >= RP_THRESHOLD])
 
     # Calculate CDI for test observation
     test_cdi <- 0
@@ -1096,6 +1123,181 @@ The critical difference is **confidence in the estimates**:
 ## Bottom Line
 
 The 2025 grid search likely found real signal, but performance estimates are optimistically biased due to in-sample optimization. The 2026 ridge approach provides more defensible estimates of true out-of-sample performance through LOOCV validation and regularization. The methodological differences (province-level vs merged area) mean direct F1 comparison is not meaningful.
+:::
+
+---
+
+## Appendix E: Composite vs Individual Forecast Components {#appendix-e-composite-vs-individual}
+
+The main CDI model uses `mixed_fcast_obsv` — an equal-weighted average of observed March precipitation, forecasted April, and forecasted May. A natural question: **does letting the model weight these three months individually improve performance?**
+
+We fit a second ridge model that replaces `mixed_fcast_obsv` with `total_precipitation_sum`, `seas5 Apr`, and `seas5 May` as separate features, then compare LOOCV performance.
+
+```{r}
+#| label: appendix-m2-ridge
+
+# Model 2: individual forecast components
+ridge_recipe_m2 <- recipe(drought ~ ., data = df_apr) |>
+    step_rm(all_of(c("pub_year", APRIL_EXCLUDE_VARS_MODEL2, "precip_cumsum"))) |>
+    step_zv(all_predictors())
+
+ridge_wf_m2 <- workflow() |>
+    add_recipe(ridge_recipe_m2) |>
+    add_model(ridge_spec)
+
+set.seed(SEED)
+ridge_boots_m2 <- bootstraps(df_apr, times = N_BOOTSTRAP, strata = drought)
+
+ridge_tune_m2 <- tune_grid(
+    ridge_wf_m2,
+    resamples = ridge_boots_m2,
+    grid = penalty_grid,
+    metrics = metric_set(roc_auc, f_meas, precision, recall),
+    control = control_grid(save_pred = TRUE)
+)
+
+best_penalty_m2 <- select_best(ridge_tune_m2, metric = "f_meas")
+final_ridge_fit_m2 <- fit(
+    ridge_wf_m2 |> finalize_workflow(best_penalty_m2),
+    data = df_apr
+)
+
+coefs_ridge_m2 <- final_ridge_fit_m2 |>
+    extract_fit_parsnip() |>
+    tidy() |>
+    filter(term != "(Intercept)")
+
+cdi_weights_m2 <- coefs_ridge_m2 |>
+    mutate(
+        weight = -estimate / sum(abs(estimate)),
+        contribution_pct = abs(weight) * 100
+    ) |>
+    arrange(desc(contribution_pct)) |>
+    select(term, estimate, weight, contribution_pct)
+```
+
+### Learned Weights
+
+Ridge does **not** weight the three months equally:
+
+```{r}
+#| label: appendix-m2-weights
+
+cdi_weights_m2 |>
+    knitr::kable(
+        digits = 3,
+        col.names = c("Indicator", "Ridge Coef", "CDI Weight", "Contribution %"),
+        caption = "CDI weights — individual components model"
+    )
+```
+
+The April forecast receives ~3x the weight of observed March precipitation or May forecast. However, the total precipitation-related contribution (~31%) is similar to the composite's weight (~28%) — the other indicators absorb the difference.
+
+### LOOCV Comparison
+
+```{r}
+#| label: appendix-m2-loocv
+
+# LOOCV for model 2
+loocv_m2_results <- map_dfr(1:nrow(df_apr), function(i) {
+    train <- df_apr[-i, ]
+    test <- df_apr[i, ]
+
+    rec <- recipe(drought ~ ., data = train) |>
+        step_rm(all_of(c("pub_year", APRIL_EXCLUDE_VARS_MODEL2, "precip_cumsum"))) |>
+        step_zv(all_predictors())
+    spec <- logistic_reg(penalty = best_penalty_m2$penalty, mixture = 0) |>
+        set_engine("glmnet") |> set_mode("classification")
+    wf <- workflow() |> add_recipe(rec) |> add_model(spec)
+    fit_result <- fit(wf, data = train)
+
+    # Get probability for ROC AUC
+    prob <- predict(fit_result, test, type = "prob")$.pred_yes
+
+    # CDI-based trigger
+    coefs <- fit_result |> extract_fit_parsnip() |> tidy() |>
+        filter(term != "(Intercept)") |>
+        mutate(weight = -estimate / sum(abs(estimate)))
+
+    train_cdi <- rep(0, nrow(train))
+    for (j in seq_len(nrow(coefs))) {
+        feat <- coefs$term[j]; w <- coefs$weight[j]
+        if (feat %in% colnames(train)) train_cdi <- train_cdi + w * train[[feat]]
+    }
+    train_rp <- rp_empirical(train_cdi, direction = "-1")
+    threshold <- min(train_cdi[train_rp >= RP_THRESHOLD])
+
+    test_cdi <- 0
+    for (j in seq_len(nrow(coefs))) {
+        feat <- coefs$term[j]; w <- coefs$weight[j]
+        if (feat %in% colnames(test)) test_cdi <- test_cdi + w * test[[feat]]
+    }
+
+    tibble(
+        year = test$pub_year,
+        actual = test$drought,
+        prob = prob,
+        predicted = if_else(test_cdi >= threshold, "yes", "no")
+    )
+})
+
+# Also get probabilities from composite LOOCV for ROC AUC
+loocv_composite_probs <- map_dfr(1:nrow(df_apr), function(i) {
+    train <- df_apr[-i, ]
+    test <- df_apr[i, ]
+
+    rec <- recipe(drought ~ ., data = train) |>
+        step_rm(all_of(c("pub_year", APRIL_EXCLUDE_VARS, "precip_cumsum"))) |>
+        step_zv(all_predictors())
+    spec <- logistic_reg(penalty = best_penalty$penalty, mixture = 0) |>
+        set_engine("glmnet") |> set_mode("classification")
+    wf <- workflow() |> add_recipe(rec) |> add_model(spec)
+    fit_result <- fit(wf, data = train)
+
+    tibble(
+        year = test$pub_year,
+        actual = test$drought,
+        prob = predict(fit_result, test, type = "prob")$.pred_yes
+    )
+})
+
+# Confusion matrix for model 2
+loocv_m2_conf <- table(
+    Predicted = factor(loocv_m2_results$predicted, levels = c("yes", "no")),
+    Actual = factor(loocv_m2_results$actual, levels = c("yes", "no"))
+)
+tp_m2 <- loocv_m2_conf["yes", "yes"]
+fp_m2 <- loocv_m2_conf["yes", "no"]
+fn_m2 <- loocv_m2_conf["no", "yes"]
+
+# Comparison table with ROC AUC
+tibble(
+    Model = c("Composite forecast", "Individual components"),
+    `N Features` = c(nrow(cdi_weights), nrow(cdi_weights_m2)),
+    `ROC AUC` = c(
+        round(yardstick::roc_auc_vec(loocv_composite_probs$actual, loocv_composite_probs$prob), 3),
+        round(yardstick::roc_auc_vec(loocv_m2_results$actual, loocv_m2_results$prob), 3)
+    ),
+    Precision = c(
+        round(tp_ridge_loo / (tp_ridge_loo + fp_ridge_loo), 3),
+        round(tp_m2 / (tp_m2 + fp_m2), 3)
+    ),
+    Recall = c(
+        round(tp_ridge_loo / (tp_ridge_loo + fn_ridge_loo), 3),
+        round(tp_m2 / (tp_m2 + fn_m2), 3)
+    ),
+    F1 = c(
+        round(2 * tp_ridge_loo / (2 * tp_ridge_loo + fp_ridge_loo + fn_ridge_loo), 3),
+        round(2 * tp_m2 / (2 * tp_m2 + fp_m2 + fn_m2), 3)
+    )
+) |>
+    knitr::kable(caption = "LOOCV comparison: Composite vs Individual component CDI")
+```
+
+::: {.callout-note}
+## Finding
+
+The two models produce **identical LOOCV performance** — same ROC AUC, F1, precision, and recall. The CDI scores are correlated at r = 0.99, so the RP-based threshold selects the same years in every fold. Ridge does allocate unequal weight across the three months (favoring the April forecast), but this doesn't change any trigger decisions. The equal-weighted `mixed_fcast_obsv` composite is a valid simplification.
 :::
 
 ---

--- a/book_afg_analysis/12_2026_trigger_modeling.qmd
+++ b/book_afg_analysis/12_2026_trigger_modeling.qmd
@@ -1636,12 +1636,11 @@ The predicted probability has a specific meaning: **P(drought) = probability tha
 
 This is a meaningful quantity, but:
 
-1. **Calibration is assumed, not verified** - With n=42 years and ridge regularization, we haven't confirmed that "70% predicted" corresponds to 70% actual drought frequency
-2. **We use percentile thresholds operationally** - The RP-based CDI threshold framework doesn't require calibrated probabilities
-3. **CDI is more interpretable** - "CDI = 1.5" relates to input z-scores; "P = 0.72" requires calibration context
+1. **We use F1-optimized thresholds** - The threshold is tuned to maximize classification performance, then expressed as an equivalent CDI value
+2. **CDI is more interpretable** - "CDI = 1.5" relates to input z-scores; "P = 0.72" requires calibration context
 
 ::: {.callout-note}
 ## Summary
 
-The CDI is mathematically equivalent to the ridge model's linear predictor (r = 1) and produces identical year rankings as the predicted probability. For percentile-based triggering, they yield the same decisions. CDI is preferred operationally for its interpretability and consistency with the return period framework. Probability would be appropriate if partners requested probabilistic risk communication.
+The CDI is mathematically equivalent to the ridge model's linear predictor (r = 1) and produces identical year rankings as the predicted probability. We tune the probability threshold to maximize F1, then derive the equivalent CDI cutoff — both produce identical trigger decisions. The F1-optimized threshold corresponds to approximately RP 3.9 (close to the policy target of RP 4). CDI is preferred operationally for its interpretability; probability would be appropriate if partners requested probabilistic risk communication.
 :::

--- a/book_afg_analysis/12_2026_trigger_modeling.qmd
+++ b/book_afg_analysis/12_2026_trigger_modeling.qmd
@@ -982,7 +982,7 @@ df_apr_compare |>
         `P(drought)` = prob_drought,
         `P>0.5` = trigger_default,
         `P>tuned` = trigger_tuned,
-        `CDI trig` = trigger
+        `CDI tuned` = trigger
     ) |>
     gt() |>
     tab_header(
@@ -1004,11 +1004,11 @@ df_apr_compare |>
     ) |>
     tab_style(
         style = cell_fill(color = "steelblue", alpha = 0.4),
-        locations = cells_body(columns = `CDI trig`, rows = `CDI trig` == "yes")
+        locations = cells_body(columns = `CDI tuned`, rows = `CDI tuned` == "yes")
     ) |>
     tab_spanner(
         label = "Trigger Decision",
-        columns = c(`P>0.5`, `P>tuned`, `CDI trig`)
+        columns = c(`P>0.5`, `P>tuned`, `CDI tuned`)
     ) |>
     tab_footnote(
         footnote = "Red = actual drought | Blue = triggered",

--- a/book_afg_analysis/13_2026_trigger_proposal.qmd
+++ b/book_afg_analysis/13_2026_trigger_proposal.qmd
@@ -34,7 +34,8 @@ box::use(
     cumulus[...],
     purrr[...],
     glue[glue],
-    tibble[tibble]
+    tibble[tibble],
+    .. / R / utils[rp_empirical]
 )
 
 library(tidymodels)
@@ -141,6 +142,18 @@ cdi_weights <- coefs_ridge |>
     ) |>
     arrange(desc(contribution_pct)) |>
     select(term, estimate, weight, contribution_pct)
+
+# F1-optimized probability threshold → CDI threshold (same derivation as ch12)
+prob_drought <- predict(final_ridge_fit, df_apr, type = "prob")$.pred_yes
+
+thresholds <- seq(0.1, 0.9, by = 0.05)
+best_prob_threshold <- map_dfr(thresholds, function(thresh) {
+    pred <- factor(if_else(prob_drought > thresh, "yes", "no"), levels = c("yes", "no"))
+    tibble(threshold = thresh, f1 = yardstick::f_meas_vec(df_apr$drought, pred))
+}) |>
+    filter(f1 == max(f1, na.rm = TRUE)) |>
+    slice(1) |>
+    pull(threshold)
 ```
 
 ```{r}
@@ -159,24 +172,23 @@ calc_cdi <- function(data, weights_df) {
     cdi
 }
 
-# Empirical RP function (higher value = worse drought = higher RP)
-rp_empirical <- function(x) {
-    r <- rank(-x, ties.method = "average")
-    q <- r / (length(x) + 1)
-    1 / q
-}
-
 # Build historical record with both signals
 df_historical <- tibble(
     year = df_apr$pub_year,
     drought_actual = df_apr$drought,
     cdi = calc_cdi(df_apr, cdi_weights),
+    prob_drought = prob_drought,
     seas5_mam = df_mar$`seas5 Mar-Apr-May`
 ) |>
     mutate(
-        cdi_rp = rp_empirical(cdi),
-        seas5_rp = rp_empirical(seas5_mam)
+        cdi_rp = rp_empirical(cdi, direction = "-1"),
+        seas5_rp = rp_empirical(seas5_mam, direction = "-1")
     )
+
+# CDI threshold from F1-optimized probability (consistent with ch12)
+cdi_threshold <- min(df_historical$cdi[df_historical$prob_drought > best_prob_threshold])
+n_trigger_tuned <- sum(df_historical$prob_drought > best_prob_threshold)
+rp_f1_equivalent <- round((nrow(df_historical) + 1) / n_trigger_tuned, 2)
 ```
 
 ## Combined RP Heatmap
@@ -258,7 +270,7 @@ The table below shows three candidate trigger configurations applied to all `r n
 
 - **SEAS5 RP4**: SEAS5 March forecast exceeds 4-year RP threshold
 - **SEAS5 RP5**: SEAS5 March forecast exceeds 5-year RP threshold
-- **CDI RP4**: April CDI exceeds 4-year RP threshold
+- **CDI**: April CDI exceeds F1-optimized threshold (≈RP `r rp_f1_equivalent`)
 
 ```{r}
 #| label: trigger-table
@@ -267,9 +279,9 @@ df_trigger <- df_historical |>
     mutate(
         seas5_rp4 = if_else(seas5_rp >= 4, "yes", "no"),
         seas5_rp5 = if_else(seas5_rp >= 5, "yes", "no"),
-        cdi_rp4 = if_else(cdi_rp >= 4, "yes", "no")
+        cdi_trig = if_else(cdi >= cdi_threshold, "yes", "no")
     ) |>
-    select(year, drought_actual, seas5_rp4, seas5_rp5, cdi_rp4) |>
+    select(year, drought_actual, seas5_rp4, seas5_rp5, cdi_trig) |>
     arrange(desc(year))
 
 df_trigger |>
@@ -278,7 +290,7 @@ df_trigger |>
         Actual = drought_actual,
         `SEAS5 RP4` = seas5_rp4,
         `SEAS5 RP5` = seas5_rp5,
-        `CDI RP4` = cdi_rp4
+        CDI = cdi_trig
     ) |>
     gt() |>
     tab_header(
@@ -299,11 +311,11 @@ df_trigger |>
     ) |>
     tab_style(
         style = cell_fill(color = "steelblue", alpha = 0.4),
-        locations = cells_body(columns = `CDI RP4`, rows = `CDI RP4` == "yes")
+        locations = cells_body(columns = CDI, rows = CDI == "yes")
     ) |>
     tab_spanner(
         label = "Trigger Decision",
-        columns = c(`SEAS5 RP4`, `SEAS5 RP5`, `CDI RP4`)
+        columns = c(`SEAS5 RP4`, `SEAS5 RP5`, CDI)
     ) |>
     tab_footnote(
         footnote = "Red = actual drought year | Blue = trigger fires",
@@ -313,7 +325,7 @@ df_trigger |>
 
 ## SEAS5 Early Warning Value
 
-Adding SEAS5 to the combined trigger does **not** rescue any drought years that CDI misses — every drought caught by SEAS5 is already caught by CDI RP4. The two missed droughts (2007 and 2025) are missed by both signals. From a pure detection standpoint, SEAS5 adds only false positives.
+Adding SEAS5 to the combined trigger does **not** rescue any drought years that CDI misses — every drought caught by SEAS5 is already caught by CDI. From a pure detection standpoint, SEAS5 adds only false positives.
 
 However, SEAS5 still has value as an **early warning signal**. Because the March forecast is available one month before the April CDI, a SEAS5 trigger gives agencies an earlier window to act. The question becomes: at what SEAS5 threshold do we get the most early warnings with the fewest false early alerts?
 
@@ -322,7 +334,7 @@ However, SEAS5 still has value as an **early warning signal**. Because the March
 
 df_early <- df_historical |>
     mutate(
-        cdi_fires = cdi_rp >= RP_THRESHOLD,
+        cdi_fires = cdi >= cdi_threshold,
         seas5_fires_rp = floor(seas5_rp)
     ) |>
     filter(drought_actual == "yes") |>
@@ -339,7 +351,7 @@ df_early <- df_historical |>
 df_early |>
     rename(
         Year = year,
-        `CDI RP4` = cdi_fires_label,
+        CDI = cdi_fires_label,
         `SEAS5 RP` = seas5_rp,
         `SEAS5 fires at` = seas5_earliest
     ) |>
@@ -351,7 +363,7 @@ df_early |>
     fmt_number(columns = `SEAS5 RP`, decimals = 1) |>
     tab_style(
         style = cell_fill(color = "steelblue", alpha = 0.4),
-        locations = cells_body(columns = `CDI RP4`, rows = `CDI RP4` == "yes")
+        locations = cells_body(columns = CDI, rows = CDI == "yes")
     )
 ```
 

--- a/book_afg_analysis/13_2026_trigger_proposal.qmd
+++ b/book_afg_analysis/13_2026_trigger_proposal.qmd
@@ -361,6 +361,149 @@ rp_grid_zoom |>
 
 At CDI ≈ RP `r rp_f1_equivalent` and SEAS5 RP 4, the combined trigger has an effective return period of approximately **`r rp_grid_zoom |> filter(cdi_threshold == tuned_cdi_snap, seas5_threshold == 4) |> pull(rp_combined)` years** — within the target RP 3–5 range for anticipatory action.
 
+## Exact RP Calculations {#exact-rp-calculations}
+
+This section provides explicit, transparent calculations for the return periods used in the 2026 trigger system.
+
+### Component Thresholds
+
+```{r}
+#| label: exact-rp-setup
+
+# CDI threshold and equivalent RP
+n_cdi_fires <- sum(df_historical$cdi >= cdi_threshold)
+cdi_rp_exact <- (nrow(df_historical) + 1) / n_cdi_fires
+
+# SEAS5 thresholds (testing RP 4 and RP 6)
+n_seas5_rp4_fires <- sum(df_historical$seas5_rp >= 4)
+n_seas5_rp6_fires <- sum(df_historical$seas5_rp >= 6)
+
+seas5_rp4_exact <- (nrow(df_historical) + 1) / n_seas5_rp4_fires
+seas5_rp6_exact <- (nrow(df_historical) + 1) / n_seas5_rp6_fires
+
+# Years where each fires
+years_cdi_fires <- df_historical$year[df_historical$cdi >= cdi_threshold]
+years_seas5_rp4_fires <- df_historical$year[df_historical$seas5_rp >= 4]
+years_seas5_rp6_fires <- df_historical$year[df_historical$seas5_rp >= 6]
+
+# Combined (OR logic)
+years_combined_rp4 <- unique(c(years_cdi_fires, years_seas5_rp4_fires))
+years_combined_rp6 <- unique(c(years_cdi_fires, years_seas5_rp6_fires))
+
+n_combined_rp4 <- length(years_combined_rp4)
+n_combined_rp6 <- length(years_combined_rp6)
+
+combined_rp_rp4 <- round(nrow(df_historical) / n_combined_rp4, 2)
+combined_rp_rp6 <- round(nrow(df_historical) / n_combined_rp6, 2)
+```
+
+| Component | Threshold | Years Firing | Empirical RP |
+|-----------|-----------|--------------|--------------|
+| **CDI (April)** | F1-optimized | `r n_cdi_fires` of `r nrow(df_historical)` | **`r round(cdi_rp_exact, 2)` years** |
+| **SEAS5 (March)** | RP ≥ 4 | `r n_seas5_rp4_fires` of `r nrow(df_historical)` | `r round(seas5_rp4_exact, 2)` years |
+| **SEAS5 (March)** | RP ≥ 6 | `r n_seas5_rp6_fires` of `r nrow(df_historical)` | `r round(seas5_rp6_exact, 2)` years |
+
+### Combined RP Calculation (OR Logic)
+
+The combined trigger fires if **either** CDI OR SEAS5 exceeds its threshold. The combined RP is calculated as:
+$$
+\text{Combined RP} = \frac{N_{\text{years}}}{\text{Years where (CDI fires) OR (SEAS5 fires)}}
+$$
+
+#### Option A: CDI + SEAS5 RP ≥ 4
+
+```{r}
+#| label: exact-rp-option-a
+#| results: asis
+
+cat("**Years where CDI fires:**\n\n")
+cat(paste(sort(years_cdi_fires), collapse = ", "), "\n\n")
+
+cat("**Years where SEAS5 RP ≥ 4 fires:**\n\n")
+cat(paste(sort(years_seas5_rp4_fires), collapse = ", "), "\n\n")
+
+cat("**Years where EITHER fires (union):**\n\n")
+cat(paste(sort(years_combined_rp4), collapse = ", "), "\n\n")
+
+cat(glue("**Calculation:** {nrow(df_historical)} years ÷ {n_combined_rp4} years triggered = **{combined_rp_rp4} year RP**\n"))
+```
+
+#### Option B: CDI + SEAS5 RP ≥ 6
+
+```{r}
+#| label: exact-rp-option-b
+#| results: asis
+
+cat("**Years where CDI fires:**\n\n")
+cat(paste(sort(years_cdi_fires), collapse = ", "), "\n\n")
+
+cat("**Years where SEAS5 RP ≥ 6 fires:**\n\n")
+cat(paste(sort(years_seas5_rp6_fires), collapse = ", "), "\n\n")
+
+cat("**Years where EITHER fires (union):**\n\n")
+cat(paste(sort(years_combined_rp6), collapse = ", "), "\n\n")
+
+cat(glue("**Calculation:** {nrow(df_historical)} years ÷ {n_combined_rp6} years triggered = **{combined_rp_rp6} year RP**\n"))
+```
+
+### Summary Table
+
+```{r}
+#| label: exact-rp-summary-table
+
+tibble(
+    `Trigger Configuration` = c(
+        "CDI only (April)",
+        "SEAS5 RP ≥ 4 only (March)",
+        "SEAS5 RP ≥ 6 only (March)",
+        "CDI OR SEAS5 RP ≥ 4",
+        "CDI OR SEAS5 RP ≥ 6"
+    ),
+    `Years Triggered` = c(
+        n_cdi_fires,
+        n_seas5_rp4_fires,
+        n_seas5_rp6_fires,
+        n_combined_rp4,
+        n_combined_rp6
+    ),
+    `Empirical RP` = c(
+        round(cdi_rp_exact, 2),
+        round(seas5_rp4_exact, 2),
+        round(seas5_rp6_exact, 2),
+        combined_rp_rp4,
+        combined_rp_rp6
+    )
+) |>
+    gt() |>
+    tab_header(
+        title = "Exact Return Period Calculations",
+        subtitle = glue("Based on {nrow(df_historical)} years of historical data (1984-2025)")
+    ) |>
+    cols_label(
+        `Trigger Configuration` = "Configuration",
+        `Years Triggered` = "N Years Fired",
+        `Empirical RP` = "RP (years)"
+    ) |>
+    tab_style(
+        style = cell_fill(color = "#E8F5E9"),
+        locations = cells_body(rows = `Trigger Configuration` == "CDI OR SEAS5 RP ≥ 6")
+    ) |>
+    tab_footnote(
+        footnote = "Green row = recommended configuration",
+        locations = cells_column_labels(columns = `Trigger Configuration`)
+    )
+```
+
+::: {.callout-important}
+## Key Numbers
+
+- **CDI threshold**: F1-optimized, equivalent to RP `r round(cdi_rp_exact, 2)` years
+- **SEAS5 threshold (recommended)**: RP ≥ 6
+- **Combined trigger RP**: `r combined_rp_rp6` years (CDI OR SEAS5 RP≥6)
+
+The combined trigger fires approximately every `r combined_rp_rp6` years, within the target range of 3-5 years for anticipatory action.
+:::
+
 ## Trigger Table
 
 The table below shows trigger configurations applied to all `r nrow(df_historical)` years. Columns:
@@ -784,3 +927,141 @@ The likely mechanism for 2007's anomalous ASI signal:
 The 2007 case is instructive: the trigger system's early-season indicators (precipitation forecasts, soil moisture, snow cover) correctly show **no drought signal** in 2007. The apparent false positive reflects a limitation of the outcome variable (ASI), not the trigger. If anything, a trigger system that *does not* fire for 2007 is behaving correctly — there was no meteorological drought to anticipate.
 
 This means the true precision of the CDI trigger may be *higher* than the LOOCV estimate, since at least one "false positive" (2007) may actually be correct.
+
+## Export Trigger Thresholds {#sec-export-thresholds}
+
+This section exports the final trigger thresholds as a single parquet file for use by the monitoring pipeline. It contains:
+
+- **SEAS5 MAM threshold** in mm (back-transformed from the RP6 z-score)
+- **CDI threshold** value (F1-optimized)
+- **CDI component weights** for computing CDI from z-scored indicators
+
+```{r}
+#| label: seas5-backtransform
+
+# --- SEAS5 RP6 z-score from empirical distribution ---
+# Interpolate to find the exact z-score corresponding to RP=6
+seas5_rp_to_z <- approxfun(
+    x = df_historical$seas5_rp,
+    y = df_historical$seas5_mam,
+    rule = 2
+)
+seas5_zscore_rp6 <- seas5_rp_to_z(6)
+
+# --- Load raw SEAS5 data to get mean/sd for back-transformation ---
+# Replicates the feature set creation pipeline (data-raw/16_*)
+PROVINCES_AOI <- c("Faryab", "Sar-e-Pul", "Jawzjan", "Balkh", "Badghis")
+
+df_seas5_raw <- cumulus::pg_load_seas5_historical(
+    iso3 = "AFG",
+    adm_name = PROVINCES_AOI,
+    adm_level = 1,
+    convert_units = TRUE
+)
+
+# Area weights for province aggregation (same source as feature set creation)
+df_area <- blob_read(
+    name = "ds-aa-afg-drought/raw/vector/historical_era5_land_ndjfmam_lte2025.parquet",
+    container = "projects"
+) |>
+    janitor::clean_names() |>
+    filter(adm1_name %in% PROVINCES_AOI) |>
+    distinct(adm1_name, shape_area)
+
+# Aggregate to MAM season, March-issued forecasts, area-weighted regional mean
+df_seas5_mam_mm <- cumulus::seas5_aggregate_forecast(
+    df = df_seas5_raw,
+    value = "mean",
+    valid_months = c(3, 4, 5),
+    by = c("iso3", "pcode", "name", "issued_date")
+) |>
+    filter(lubridate::month(issued_date) == 3) |>
+    rename(adm1_name = name, value = mean) |>
+    left_join(df_area, by = "adm1_name") |>
+    group_by(issued_date) |>
+    summarise(
+        value = weighted.mean(value, w = shape_area, na.rm = TRUE),
+        .groups = "drop"
+    ) |>
+    filter(lubridate::year(issued_date) >= 1984)
+
+# Back-transform: z = -(value - mean) / sd  →  value = mean - z * sd
+seas5_mean_mm <- mean(df_seas5_mam_mm$value)
+seas5_sd_mm <- sd(df_seas5_mam_mm$value)
+seas5_mm_rp6 <- seas5_mean_mm - seas5_zscore_rp6 * seas5_sd_mm
+```
+
+```{r}
+#| label: build-thresholds-df
+
+df_thresholds <- tibble(
+    indicator = c("seas5_mam", "cdi"),
+    window = c("march", "april"),
+    threshold_value = c(seas5_mm_rp6, cdi_threshold),
+    threshold_unit = c("mm", "cdi_index"),
+    rp_equivalent = c(6, rp_f1_equivalent),
+    w_mixed_fcast_obsv = c(NA_real_, cdi_weights$weight[cdi_weights$term == "mixed_fcast_obsv"]),
+    w_asi = c(NA_real_, cdi_weights$weight[cdi_weights$term == "asi"]),
+    w_snow_cover = c(NA_real_, cdi_weights$weight[cdi_weights$term == "snow_cover"]),
+    w_vhi = c(NA_real_, cdi_weights$weight[cdi_weights$term == "vhi"]),
+    w_volumetric_soil_water_1m = c(NA_real_, cdi_weights$weight[cdi_weights$term == "volumetric_soil_water_1m"])
+)
+
+df_thresholds |>
+    knitr::kable(
+        digits = 3,
+        caption = "Trigger thresholds for 2026 monitoring pipeline"
+    )
+```
+
+```{r}
+#| label: verify-backtransform
+#| results: asis
+
+# Sanity check: verify back-transformation by joining on year
+df_verify <- df_seas5_mam_mm |>
+    mutate(
+        pub_year = lubridate::year(issued_date),
+        derived_z = -(value - seas5_mean_mm) / seas5_sd_mm
+    ) |>
+    inner_join(
+        tibble(pub_year = df_historical$year, feature_z = df_historical$seas5_mam),
+        by = "pub_year"
+    )
+
+z_cor <- round(cor(df_verify$derived_z, df_verify$feature_z), 6)
+
+cat(glue("**Back-transformation verification:**\n\n"))
+cat(glue("- SEAS5 mean (mm): {round(seas5_mean_mm, 2)}\n\n"))
+cat(glue("- SEAS5 sd (mm): {round(seas5_sd_mm, 2)}\n\n"))
+cat(glue("- RP6 z-score: {round(seas5_zscore_rp6, 3)}\n\n"))
+cat(glue("- **RP6 threshold (mm): {round(seas5_mm_rp6, 2)}**\n\n"))
+cat(glue("- Correlation (re-derived z vs feature set z, joined by year): {z_cor}\n\n"))
+```
+
+```{r}
+#| label: write-thresholds
+#| eval: false
+
+blob_write(
+    df = df_thresholds,
+    name = "ds-aa-afg-drought/monitoring_inputs/2026/trigger_thresholds.parquet",
+    stage = "dev",
+    container = "projects"
+)
+```
+
+::: {.callout-note}
+## Thresholds Exported
+
+The trigger thresholds have been written to blob at:
+
+`ds-aa-afg-drought/monitoring_inputs/2026/trigger_thresholds.parquet`
+
+To use in the monitoring pipeline:
+
+1. **SEAS5 (March)**: Compare regional area-weighted MAM forecast (mm) against `threshold_value` where `indicator == "seas5_mam"`. **Trigger if forecast ≤ threshold** (low precipitation = drought).
+2. **CDI (April)**: Compute CDI from z-scored indicators using the `w_*` columns, then compare against `threshold_value` where `indicator == "cdi"`. **Trigger if CDI ≥ threshold** (high CDI = drought).
+
+Note: SEAS5 and CDI have **opposite directionality** — SEAS5 triggers on values *below* the threshold (dry forecast), CDI triggers on values *above* the threshold (drought signal).
+:::

--- a/book_afg_analysis/13_2026_trigger_proposal.qmd
+++ b/book_afg_analysis/13_2026_trigger_proposal.qmd
@@ -1,0 +1,488 @@
+---
+title: "2026 Trigger Proposal (Combined RP)"
+format:
+  html:
+    toc: true
+    toc-depth: 3
+    code-fold: true
+execute:
+  warning: false
+  message: false
+project:
+  execute-dir: project
+---
+
+## Introduction
+
+This chapter proposes a **two-stage trigger** for the 2026 anticipatory action framework. The idea is to combine two independent signals at different lead times using OR logic:
+
+1. **SEAS5 March window** (early lead time): If the COPERNICUS SEAS5 seasonal precipitation forecast exceeds a return period threshold, trigger early.
+2. **CDI April window** (better observational data): If the ridge-based Combined Drought Index exceeds a return period threshold, trigger in April.
+
+A year triggers if **either** signal fires. This increases sensitivity (fewer missed droughts) at the cost of more frequent activation.
+
+See @sec-2026-trigger-modeling for CDI model derivation and validation.
+
+```{r}
+#| label: setup
+
+box::use(
+    dplyr[...],
+    tidyr[...],
+    ggplot2[...],
+    gghdx[...],
+    cumulus[...],
+    purrr[...],
+    glue[glue],
+    tibble[tibble]
+)
+
+library(tidymodels)
+library(gt)
+gghdx()
+```
+
+```{r}
+#| label: config
+
+# Return period threshold for defining drought
+RP_THRESHOLD <- 4
+
+# Random seed
+SEED <- 42
+
+# Bootstrap resamples
+N_BOOTSTRAP <- 30
+
+# Feature set paths
+FEATURE_PATHS <- list(
+    march = "ds-aa-afg-drought/processed/vector/2026_mar_pub_feature_set_v1.parquet",
+    april = "ds-aa-afg-drought/processed/vector/2026_april_pub_feature_set_v1.parquet"
+)
+
+# Variables to exclude from CDI model (same as ch12)
+APRIL_EXCLUDE_VARS <- c("total_precipitation_sum", "seas5 Apr", "seas5 May")
+```
+
+## Data & Model
+
+```{r}
+#| label: load-data
+
+# Load feature sets
+df_mar_raw <- blob_read(name = FEATURE_PATHS$march, container = "projects")
+df_apr_raw <- blob_read(name = FEATURE_PATHS$april, container = "projects")
+
+# Prepare modeling data with empirical RP thresholding
+prepare_model_data <- function(df, rp_threshold = RP_THRESHOLD) {
+    df |>
+        filter(!is.na(outcome_asi_zscore)) |>
+        arrange(desc(outcome_asi_zscore)) |>
+        mutate(
+            rank = row_number(),
+            q_rank = rank / (n() + 1),
+            rp_emp = 1 / q_rank,
+            drought = factor(
+                if_else(rp_emp >= rp_threshold, "yes", "no"),
+                levels = c("yes", "no")
+            )
+        ) |>
+        select(-outcome_asi_zscore, -rank, -q_rank, -rp_emp,
+               -starts_with("adm0_name"), -pub_date, -timestep)
+}
+
+df_mar <- prepare_model_data(df_mar_raw)
+df_apr <- prepare_model_data(df_apr_raw)
+```
+
+```{r}
+#| label: fit-ridge
+
+# Ridge specification
+ridge_spec <- logistic_reg(penalty = tune(), mixture = 0) |>
+    set_engine("glmnet") |>
+    set_mode("classification")
+
+# Recipe (exclude composite components + precip_cumsum, same as ch12)
+ridge_recipe <- recipe(drought ~ ., data = df_apr) |>
+    step_rm(all_of(c("pub_year", APRIL_EXCLUDE_VARS, "precip_cumsum"))) |>
+    step_zv(all_predictors())
+
+ridge_wf <- workflow() |>
+    add_recipe(ridge_recipe) |>
+    add_model(ridge_spec)
+
+# Tune penalty
+set.seed(SEED)
+ridge_boots <- bootstraps(df_apr, times = N_BOOTSTRAP, strata = drought)
+penalty_grid <- grid_regular(penalty(range = c(-4, 0)), levels = 30)
+
+ridge_tune <- tune_grid(
+    ridge_wf,
+    resamples = ridge_boots,
+    grid = penalty_grid,
+    metrics = metric_set(roc_auc, f_meas),
+    control = control_grid(save_pred = TRUE)
+)
+
+best_penalty <- select_best(ridge_tune, metric = "f_meas")
+final_ridge_fit <- fit(finalize_workflow(ridge_wf, best_penalty), data = df_apr)
+
+# Extract CDI weights
+coefs_ridge <- final_ridge_fit |>
+    extract_fit_parsnip() |>
+    tidy() |>
+    filter(term != "(Intercept)")
+
+cdi_weights <- coefs_ridge |>
+    mutate(
+        weight = -estimate / sum(abs(estimate)),
+        contribution_pct = abs(weight) * 100
+    ) |>
+    arrange(desc(contribution_pct)) |>
+    select(term, estimate, weight, contribution_pct)
+```
+
+```{r}
+#| label: compute-historical
+
+# CDI calculation helper
+calc_cdi <- function(data, weights_df) {
+    cdi <- rep(0, nrow(data))
+    for (i in seq_len(nrow(weights_df))) {
+        feat <- weights_df$term[i]
+        w <- weights_df$weight[i]
+        if (feat %in% colnames(data)) {
+            cdi <- cdi + w * data[[feat]]
+        }
+    }
+    cdi
+}
+
+# Empirical RP function (higher value = worse drought = higher RP)
+rp_empirical <- function(x) {
+    r <- rank(-x, ties.method = "average")
+    q <- r / (length(x) + 1)
+    1 / q
+}
+
+# Build historical record with both signals
+df_historical <- tibble(
+    year = df_apr$pub_year,
+    drought_actual = df_apr$drought,
+    cdi = calc_cdi(df_apr, cdi_weights),
+    seas5_mam = df_mar$`seas5 Mar-Apr-May`
+) |>
+    mutate(
+        cdi_rp = rp_empirical(cdi),
+        seas5_rp = rp_empirical(seas5_mam)
+    )
+```
+
+## Combined RP Heatmap
+
+The heatmap below shows the **effective return period** of the combined two-stage trigger across all combinations of CDI and SEAS5 thresholds. OR logic means a year triggers if *either* signal exceeds its threshold.
+
+```{r}
+#| label: combined-rp-grid
+
+rp_grid <- expand_grid(
+    cdi_threshold = 3:7,
+    seas5_threshold = 3:7
+) |>
+    pmap_dfr(function(cdi_threshold, seas5_threshold) {
+        n_either <- df_historical |>
+            filter(cdi_rp >= cdi_threshold | seas5_rp >= seas5_threshold) |>
+            nrow()
+
+        tibble(
+            cdi_threshold = cdi_threshold,
+            seas5_threshold = seas5_threshold,
+            n_triggered = n_either,
+            n_years = nrow(df_historical),
+            rp_combined = if (n_either > 0) round(nrow(df_historical) / n_either, 1) else Inf
+        )
+    })
+```
+
+```{r}
+#| label: combined-rp-heatmap
+#| fig-height: 6
+#| fig-width: 7
+
+rp_grid |>
+    mutate(
+        rp_label = if_else(
+            is.infinite(rp_combined),
+            "never",
+            as.character(rp_combined)
+        ),
+        rp_fill = if_else(
+            is.infinite(rp_combined),
+            max(rp_combined[is.finite(rp_combined)]) + 5,
+            rp_combined
+        ),
+        target_zone = rp_combined >= 3 & rp_combined <= 5 & is.finite(rp_combined)
+    ) |>
+    ggplot(aes(
+        x = factor(cdi_threshold),
+        y = factor(seas5_threshold),
+        fill = rp_fill
+    )) +
+    geom_tile(color = "white", linewidth = 1) +
+    geom_text(aes(label = rp_label), fontface = "bold", size = 4.5) +
+    geom_tile(
+        data = \(d) filter(d, target_zone),
+        aes(x = factor(cdi_threshold), y = factor(seas5_threshold)),
+        fill = NA, color = "black", linewidth = 1.5
+    ) +
+    scale_fill_gradient2(
+        low = "tomato", mid = "khaki", high = "steelblue",
+        midpoint = 5,
+        name = "Combined\nRP (years)"
+    ) +
+    labs(
+        title = "Combined Return Period: Two-Stage Trigger (OR Logic)",
+        subtitle = "Black border = RP 3\u20135 target zone",
+        x = "CDI Threshold (RP, years)",
+        y = "SEAS5 March Threshold (RP, years)"
+    ) +
+    theme(panel.grid = element_blank())
+```
+
+**Interpretation**: Lower-left cells (both thresholds lenient) fire frequently and have low combined RP. Upper-right cells (both thresholds strict) fire rarely. The **RP 3–5 target zone** (black border) identifies threshold pairs consistent with the program's desired activation frequency. Because OR logic combines two signals, the combined RP is always less than or equal to the minimum of the individual RPs.
+
+## Trigger Table
+
+The table below shows three candidate trigger configurations applied to all `r nrow(df_historical)` years. Columns:
+
+- **SEAS5 RP4**: SEAS5 March forecast exceeds 4-year RP threshold
+- **SEAS5 RP5**: SEAS5 March forecast exceeds 5-year RP threshold
+- **CDI RP4**: April CDI exceeds 4-year RP threshold
+
+```{r}
+#| label: trigger-table
+
+df_trigger <- df_historical |>
+    mutate(
+        seas5_rp4 = if_else(seas5_rp >= 4, "yes", "no"),
+        seas5_rp5 = if_else(seas5_rp >= 5, "yes", "no"),
+        cdi_rp4 = if_else(cdi_rp >= 4, "yes", "no")
+    ) |>
+    select(year, drought_actual, seas5_rp4, seas5_rp5, cdi_rp4) |>
+    arrange(desc(year))
+
+df_trigger |>
+    rename(
+        Year = year,
+        Actual = drought_actual,
+        `SEAS5 RP4` = seas5_rp4,
+        `SEAS5 RP5` = seas5_rp5,
+        `CDI RP4` = cdi_rp4
+    ) |>
+    gt() |>
+    tab_header(
+        title = "Year-by-Year Trigger Decisions",
+        subtitle = "All 42 years | Red = actual drought | Blue = triggered"
+    ) |>
+    tab_style(
+        style = cell_fill(color = "tomato", alpha = 0.4),
+        locations = cells_body(columns = Actual, rows = Actual == "yes")
+    ) |>
+    tab_style(
+        style = cell_fill(color = "steelblue", alpha = 0.4),
+        locations = cells_body(columns = `SEAS5 RP4`, rows = `SEAS5 RP4` == "yes")
+    ) |>
+    tab_style(
+        style = cell_fill(color = "steelblue", alpha = 0.4),
+        locations = cells_body(columns = `SEAS5 RP5`, rows = `SEAS5 RP5` == "yes")
+    ) |>
+    tab_style(
+        style = cell_fill(color = "steelblue", alpha = 0.4),
+        locations = cells_body(columns = `CDI RP4`, rows = `CDI RP4` == "yes")
+    ) |>
+    tab_spanner(
+        label = "Trigger Decision",
+        columns = c(`SEAS5 RP4`, `SEAS5 RP5`, `CDI RP4`)
+    ) |>
+    tab_footnote(
+        footnote = "Red = actual drought year | Blue = trigger fires",
+        locations = cells_column_spanners()
+    )
+```
+
+## SEAS5 Early Warning Value
+
+Adding SEAS5 to the combined trigger does **not** rescue any drought years that CDI misses — every drought caught by SEAS5 is already caught by CDI RP4. The two missed droughts (2007 and 2025) are missed by both signals. From a pure detection standpoint, SEAS5 adds only false positives.
+
+However, SEAS5 still has value as an **early warning signal**. Because the March forecast is available one month before the April CDI, a SEAS5 trigger gives agencies an earlier window to act. The question becomes: at what SEAS5 threshold do we get the most early warnings with the fewest false early alerts?
+
+```{r}
+#| label: early-warning-by-year
+
+df_early <- df_historical |>
+    mutate(
+        cdi_fires = cdi_rp >= RP_THRESHOLD,
+        seas5_fires_rp = floor(seas5_rp)
+    ) |>
+    filter(drought_actual == "yes") |>
+    arrange(desc(seas5_rp)) |>
+    mutate(
+        seas5_earliest = case_when(
+            seas5_rp >= 3 ~ paste0("RP>=", pmin(seas5_fires_rp, 7)),
+            TRUE ~ "never"
+        ),
+        cdi_fires_label = if_else(cdi_fires, "yes", "no")
+    ) |>
+    select(year, cdi_fires_label, seas5_rp, seas5_earliest)
+
+df_early |>
+    rename(
+        Year = year,
+        `CDI RP4` = cdi_fires_label,
+        `SEAS5 RP` = seas5_rp,
+        `SEAS5 fires at` = seas5_earliest
+    ) |>
+    gt() |>
+    tab_header(
+        title = "Drought Years: When Does Each Signal Fire?",
+        subtitle = "CDI fires in April; SEAS5 fires in March (one month earlier)"
+    ) |>
+    fmt_number(columns = `SEAS5 RP`, decimals = 1) |>
+    tab_style(
+        style = cell_fill(color = "steelblue", alpha = 0.4),
+        locations = cells_body(columns = `CDI RP4`, rows = `CDI RP4` == "yes")
+    )
+```
+
+For each SEAS5 threshold, we can count how many drought years get early warning vs how many non-drought years produce false early alerts:
+
+```{r}
+#| label: early-warning-summary
+
+df_ew_summary <- map_dfr(3:7, function(rp) {
+    seas5_fires <- df_historical$seas5_rp >= rp
+
+    droughts_early <- sum(seas5_fires & df_historical$drought_actual == "yes")
+    false_early <- sum(seas5_fires & df_historical$drought_actual == "no")
+    n_drought <- sum(df_historical$drought_actual == "yes")
+
+    tibble(
+        seas5_threshold = paste0("RP>=", rp),
+        droughts_with_early_warning = droughts_early,
+        total_droughts = n_drought,
+        pct_early = round(droughts_early / n_drought * 100, 0),
+        false_early_alerts = false_early,
+        early_to_false_ratio = if (false_early > 0) {
+            paste0(round(droughts_early / false_early, 1), ":1")
+        } else {
+            paste0(droughts_early, ":0")
+        }
+    )
+})
+
+df_ew_summary |>
+    rename(
+        `SEAS5 Threshold` = seas5_threshold,
+        `Droughts w/ early warning` = droughts_with_early_warning,
+        `Total droughts` = total_droughts,
+        `% early` = pct_early,
+        `False early alerts` = false_early_alerts,
+        `Early:False ratio` = early_to_false_ratio
+    ) |>
+    gt() |>
+    tab_header(
+        title = "SEAS5 Early Warning Performance by Threshold",
+        subtitle = "How many droughts get a one-month head start?"
+    )
+```
+
+::: {.callout-note}
+## SEAS5 Threshold Recommendation
+
+**RP ≥ 4** maximizes early warning value:
+
+- **6 of 10** drought years get early warning (March instead of April)
+- **4 false early alerts** over 42 years
+- **Best early:false ratio** (1.5:1)
+
+Raising to RP ≥ 5 drops 2021 and 2023 (recent droughts) without removing any false positives. Lowering to RP ≥ 3 adds one more drought (2022) but also five more false alerts, dropping the ratio to 1:1.
+:::
+
+## The 2007 Anomaly {#sec-2007-anomaly}
+
+::: {.callout-warning}
+## 2007: False Positive or Misattributed Outcome?
+
+2007 consistently appears as a **false positive** across trigger configurations — the CDI triggers but the ASI outcome does not classify 2007 as a drought year. However, closer inspection suggests the *outcome variable* may be misleading, not the trigger.
+:::
+
+### Component-Level Evidence
+
+The table below compares 2007's indicator z-scores to the average across confirmed drought years:
+
+```{r}
+#| label: 2007-components
+
+cdi_component_cols <- cdi_weights$term
+
+df_components_2007 <- df_apr |>
+    mutate(year = pub_year) |>
+    select(year, drought, all_of(cdi_component_cols))
+
+# 2007 values
+vals_2007 <- df_components_2007 |>
+    filter(year == 2007) |>
+    pivot_longer(cols = all_of(cdi_component_cols),
+                 names_to = "component", values_to = "zscore_2007") |>
+    select(component, zscore_2007)
+
+# Drought year averages
+vals_drought_avg <- df_components_2007 |>
+    filter(drought == "yes") |>
+    summarise(across(all_of(cdi_component_cols), mean)) |>
+    pivot_longer(everything(), names_to = "component", values_to = "drought_avg")
+
+# 2007 rank per component
+vals_rank <- df_components_2007 |>
+    mutate(across(
+        all_of(cdi_component_cols),
+        \(x) rank(-x, ties.method = "average"),
+        .names = "{.col}_rank"
+    )) |>
+    filter(year == 2007) |>
+    select(ends_with("_rank")) |>
+    pivot_longer(everything(), names_to = "component", values_to = "rank") |>
+    mutate(
+        component = gsub("_rank$", "", component),
+        component_rp = round(nrow(df_components_2007) / rank, 1)
+    )
+
+vals_2007 |>
+    left_join(vals_drought_avg, by = "component") |>
+    left_join(vals_rank, by = "component") |>
+    select(component, zscore_2007, drought_avg, rank, component_rp) |>
+    mutate(across(where(is.numeric), \(x) round(x, 2))) |>
+    knitr::kable(
+        col.names = c("Component", "2007 Z-score", "Drought Avg", "Rank (of 42)", "Component RP"),
+        caption = "2007 component-level z-scores vs drought year averages"
+    )
+```
+
+### Explanation: 2006 Drought Displacement
+
+2006 was a confirmed severe drought year. A [Joint Appeal for Afghanistan Drought](https://reliefweb.int/report/afghanistan/joint-appeal-afghanistan-drought-jul-2006) was launched in July 2006 due to inadequate April–May rainfall. [UNHCR](https://www.unhcr.org/4918482e4.html) and [ReliefWeb situation reports](https://reliefweb.int/report/afghanistan/afghanistan-drought-situation-provinces-balkh-juzjan-and-faryab) document significant displacement from exactly our AOI provinces (Faryab, Badghis, Sar-e-Pul, Balkh, Jawzjan) during the 2006 drought — families left, some dismantling their houses indicating no intent to return, and WFP planting surveys showed exceptionally low planting levels across Jawzjan, Faryab, and Samangan.
+
+The likely mechanism for 2007's anomalous ASI signal:
+
+1. **2006 drought** caused widespread crop failure and population displacement in northern provinces
+2. Displaced farming households left fields **fallow** in 2007
+3. The FAO Agricultural Stress Index (ASI) measures vegetation health via remote sensing — it **cannot distinguish fallow fields from drought-stressed crops**
+4. Fallow fields in 2007 registered as low vegetation, producing an elevated ASI z-score
+5. This makes 2007 appear as a "drought year" in the outcome variable when it was actually a **displacement aftermath**
+
+### Implication for the Trigger System
+
+The 2007 case is instructive: the trigger system's early-season indicators (precipitation forecasts, soil moisture, snow cover) correctly show **no drought signal** in 2007. The apparent false positive reflects a limitation of the outcome variable (ASI), not the trigger. If anything, a trigger system that *does not* fire for 2007 is behaving correctly — there was no meteorological drought to anticipate.
+
+This means the true precision of the CDI trigger may be *higher* than the LOOCV estimate, since at least one "false positive" (2007) may actually be correct.

--- a/book_afg_analysis/13_2026_trigger_proposal.qmd
+++ b/book_afg_analysis/13_2026_trigger_proposal.qmd
@@ -157,6 +157,23 @@ best_prob_threshold <- map_dfr(thresholds, function(thresh) {
 ```
 
 ```{r}
+#| label: cdi-formula
+#| results: asis
+
+formula_parts <- cdi_weights |>
+    arrange(desc(weight)) |>
+    mutate(
+        part = paste0(
+            if_else(row_number() == 1, "", " + "),
+            round(weight, 3), " × ", term
+        )
+    ) |>
+    pull(part)
+
+cat("**CDI Formula:**\n\n$$\\text{CDI} = ", paste(formula_parts, collapse = ""), "$$\n")
+```
+
+```{r}
 #| label: compute-historical
 
 # CDI calculation helper

--- a/book_afg_analysis/13_2026_trigger_proposal.qmd
+++ b/book_afg_analysis/13_2026_trigger_proposal.qmd
@@ -281,12 +281,91 @@ rp_grid |>
 
 **Interpretation**: Lower-left cells (both thresholds lenient) fire frequently and have low combined RP. Upper-right cells (both thresholds strict) fire rarely. The **RP 3–5 target zone** (black border) identifies threshold pairs consistent with the program's desired activation frequency. Because OR logic combines two signals, the combined RP is always less than or equal to the minimum of the individual RPs.
 
+### Zoomed View: Proposed Threshold
+
+The zoomed view below uses finer increments (0.2) to show exactly where our proposed threshold sits. The black-bordered cell marks CDI ≈ RP `r rp_f1_equivalent` (F1-tuned) combined with SEAS5 RP 4 (best early:false ratio).
+
+```{r}
+#| label: combined-rp-zoom
+#| fig-height: 6
+#| fig-width: 7
+
+# Fine-grained RP breaks
+rp_fine <- seq(3, 5, by = 0.2)
+
+# Snap our tuned RP to nearest grid point
+tuned_cdi_snap <- rp_fine[which.min(abs(rp_fine - rp_f1_equivalent))]
+
+rp_grid_zoom <- expand_grid(
+    cdi_threshold = rp_fine,
+    seas5_threshold = rp_fine
+) |>
+    pmap_dfr(function(cdi_threshold, seas5_threshold) {
+        n_either <- df_historical |>
+            filter(cdi_rp >= cdi_threshold | seas5_rp >= seas5_threshold) |>
+            nrow()
+
+        tibble(
+            cdi_threshold = cdi_threshold,
+            seas5_threshold = seas5_threshold,
+            n_triggered = n_either,
+            n_years = nrow(df_historical),
+            rp_combined = if (n_either > 0) round(nrow(df_historical) / n_either, 1) else Inf
+        )
+    })
+
+rp_grid_zoom |>
+    mutate(
+        rp_label = if_else(
+            is.infinite(rp_combined),
+            "never",
+            as.character(rp_combined)
+        ),
+        rp_fill = if_else(
+            is.infinite(rp_combined),
+            max(rp_combined[is.finite(rp_combined)]) + 5,
+            rp_combined
+        )
+    ) |>
+    ggplot(aes(
+        x = factor(cdi_threshold),
+        y = factor(seas5_threshold),
+        fill = rp_fill
+    )) +
+    geom_tile(color = "white", linewidth = 0.5) +
+    geom_text(aes(label = rp_label), fontface = "bold", size = 2.5) +
+    # Highlight proposed threshold
+    annotate("rect",
+             xmin = which(rp_fine == tuned_cdi_snap) - 0.5,
+             xmax = which(rp_fine == tuned_cdi_snap) + 0.5,
+             ymin = which(rp_fine == 4) - 0.5,
+             ymax = which(rp_fine == 4) + 0.5,
+             fill = NA, color = "black", linewidth = 2) +
+    scale_fill_gradient2(
+        low = "tomato", mid = "khaki", high = "steelblue",
+        midpoint = 5,
+        name = "Combined\nRP (years)"
+    ) +
+    labs(
+        title = "Zoomed: Combined Return Period (RP 3–5 range)",
+        subtitle = glue("Black border = proposed threshold (CDI ≈ RP {rp_f1_equivalent}, SEAS5 RP 4)"),
+        x = "CDI Threshold (RP, years)",
+        y = "SEAS5 March Threshold (RP, years)"
+    ) +
+    theme(
+        panel.grid = element_blank(),
+        axis.text.x = element_text(size = 7, angle = 45, hjust = 1),
+        axis.text.y = element_text(size = 7)
+    )
+```
+
+At CDI ≈ RP `r rp_f1_equivalent` and SEAS5 RP 4, the combined trigger has an effective return period of approximately **`r rp_grid_zoom |> filter(cdi_threshold == tuned_cdi_snap, seas5_threshold == 4) |> pull(rp_combined)` years** — within the target RP 3–5 range for anticipatory action.
+
 ## Trigger Table
 
-The table below shows three candidate trigger configurations applied to all `r nrow(df_historical)` years. Columns:
+The table below shows trigger configurations applied to all `r nrow(df_historical)` years. Columns:
 
-- **SEAS5 RP4**: SEAS5 March forecast exceeds 4-year RP threshold
-- **SEAS5 RP5**: SEAS5 March forecast exceeds 5-year RP threshold
+- **SEAS5 RP4–7**: SEAS5 March forecast exceeds the given RP threshold
 - **CDI**: April CDI exceeds F1-optimized threshold (≈RP `r rp_f1_equivalent`)
 
 ```{r}
@@ -296,17 +375,21 @@ df_trigger <- df_historical |>
     mutate(
         seas5_rp4 = if_else(seas5_rp >= 4, "yes", "no"),
         seas5_rp5 = if_else(seas5_rp >= 5, "yes", "no"),
+        seas5_rp6 = if_else(seas5_rp >= 6, "yes", "no"),
+        seas5_rp7 = if_else(seas5_rp >= 7, "yes", "no"),
         cdi_trig = if_else(cdi >= cdi_threshold, "yes", "no")
     ) |>
-    select(year, drought_actual, seas5_rp4, seas5_rp5, cdi_trig) |>
+    select(year, drought_actual, seas5_rp4, seas5_rp5, seas5_rp6, seas5_rp7, cdi_trig) |>
     arrange(desc(year))
 
 df_trigger |>
     rename(
         Year = year,
         Actual = drought_actual,
-        `SEAS5 RP4` = seas5_rp4,
-        `SEAS5 RP5` = seas5_rp5,
+        `RP4` = seas5_rp4,
+        `RP5` = seas5_rp5,
+        `RP6` = seas5_rp6,
+        `RP7` = seas5_rp7,
         CDI = cdi_trig
     ) |>
     gt() |>
@@ -320,19 +403,27 @@ df_trigger |>
     ) |>
     tab_style(
         style = cell_fill(color = "steelblue", alpha = 0.4),
-        locations = cells_body(columns = `SEAS5 RP4`, rows = `SEAS5 RP4` == "yes")
+        locations = cells_body(columns = RP4, rows = RP4 == "yes")
     ) |>
     tab_style(
         style = cell_fill(color = "steelblue", alpha = 0.4),
-        locations = cells_body(columns = `SEAS5 RP5`, rows = `SEAS5 RP5` == "yes")
+        locations = cells_body(columns = RP5, rows = RP5 == "yes")
+    ) |>
+    tab_style(
+        style = cell_fill(color = "steelblue", alpha = 0.4),
+        locations = cells_body(columns = RP6, rows = RP6 == "yes")
+    ) |>
+    tab_style(
+        style = cell_fill(color = "steelblue", alpha = 0.4),
+        locations = cells_body(columns = RP7, rows = RP7 == "yes")
     ) |>
     tab_style(
         style = cell_fill(color = "steelblue", alpha = 0.4),
         locations = cells_body(columns = CDI, rows = CDI == "yes")
     ) |>
     tab_spanner(
-        label = "Trigger Decision",
-        columns = c(`SEAS5 RP4`, `SEAS5 RP5`, CDI)
+        label = "SEAS5",
+        columns = c(RP4, RP5, RP6, RP7)
     ) |>
     tab_footnote(
         footnote = "Red = actual drought year | Blue = trigger fires",
@@ -389,11 +480,18 @@ For each SEAS5 threshold, we can count how many drought years get early warning 
 ```{r}
 #| label: early-warning-summary
 
+cdi_fires <- df_historical$cdi >= cdi_threshold
+
 df_ew_summary <- map_dfr(3:7, function(rp) {
     seas5_fires <- df_historical$seas5_rp >= rp
 
     droughts_early <- sum(seas5_fires & df_historical$drought_actual == "yes")
-    false_early <- sum(seas5_fires & df_historical$drought_actual == "no")
+    false_early_total <- sum(seas5_fires & df_historical$drought_actual == "no")
+    # False alerts ADDED by SEAS5 = SEAS5 fires, CDI doesn't, not a drought
+    fp_added_mask <- seas5_fires & !cdi_fires & df_historical$drought_actual == "no"
+    false_early_added <- sum(fp_added_mask)
+    years_added <- df_historical$year[fp_added_mask]
+    years_added_str <- if (length(years_added) > 0) paste(sort(years_added), collapse = ", ") else "—"
     n_drought <- sum(df_historical$drought_actual == "yes")
 
     tibble(
@@ -401,9 +499,11 @@ df_ew_summary <- map_dfr(3:7, function(rp) {
         droughts_with_early_warning = droughts_early,
         total_droughts = n_drought,
         pct_early = round(droughts_early / n_drought * 100, 0),
-        false_early_alerts = false_early,
-        early_to_false_ratio = if (false_early > 0) {
-            paste0(round(droughts_early / false_early, 1), ":1")
+        false_early_total = false_early_total,
+        false_early_added = false_early_added,
+        years_added = years_added_str,
+        early_to_added_ratio = if (false_early_added > 0) {
+            paste0(round(droughts_early / false_early_added, 1), ":1")
         } else {
             paste0(droughts_early, ":0")
         }
@@ -416,26 +516,195 @@ df_ew_summary |>
         `Droughts w/ early warning` = droughts_with_early_warning,
         `Total droughts` = total_droughts,
         `% early` = pct_early,
-        `False early alerts` = false_early_alerts,
-        `Early:False ratio` = early_to_false_ratio
+        `FP (total)` = false_early_total,
+        `FP (added)` = false_early_added,
+        `Years added` = years_added,
+        `Early Warning:FP` = early_to_added_ratio
     ) |>
     gt() |>
     tab_header(
         title = "SEAS5 Early Warning Performance by Threshold",
-        subtitle = "How many droughts get a one-month head start?"
+        subtitle = "FP (added) = false positives where SEAS5 fires but CDI doesn't"
+    )
+```
+
+```{r}
+#| label: early-added-ratio-plot
+#| fig-height: 4
+#| fig-width: 6
+
+df_ew_plot <- df_ew_summary |>
+    mutate(
+        rp = as.numeric(gsub("RP>=", "", seas5_threshold)),
+        # Parse ratio - handle "X:0" case
+        ratio_numeric = if_else(
+            false_early_added == 0,
+            droughts_with_early_warning,  # If no FP added, ratio is just the numerator
+            droughts_with_early_warning / false_early_added
+        )
+    )
+
+ggplot(df_ew_plot, aes(x = rp, y = ratio_numeric)) +
+    geom_line(linewidth = 1, color = hdx_hex("sapphire-hdx")) +
+    geom_point(size = 3, color = hdx_hex("sapphire-hdx")) +
+    geom_text(aes(label = early_to_added_ratio), vjust = -1.2, size = 3) +
+    geom_hline(yintercept = 1, linetype = "dashed", color = "grey50") +
+    annotate("text", x = 7, y = 1, label = "1:1 break-even", hjust = 1, vjust = 1.5,
+             size = 3, color = "grey50") +
+    scale_x_continuous(breaks = 3:7) +
+    scale_y_continuous(limits = c(0, max(df_ew_plot$ratio_numeric) * 1.25), expand = c(0, 0)) +
+    labs(
+        title = "SEAS5 Value Add",
+        subtitle = "Droughts warned early per false alert added (Early Warning / FP)",
+        x = "SEAS5 RP Threshold",
+        y = "SEAS5 Value Add Ratio"
     )
 ```
 
 ::: {.callout-note}
 ## SEAS5 Threshold Recommendation
 
+The key metric is **FP (added)** — false positives that SEAS5 contributes beyond what CDI already triggers. These are the alerts that actually hurt combined performance under OR logic.
+
 **RP ≥ 4** maximizes early warning value:
 
 - **6 of 10** drought years get early warning (March instead of April)
-- **4 false early alerts** over 42 years
-- **Best early:false ratio** (1.5:1)
+- Only **`r df_ew_summary |> filter(seas5_threshold == "RP>=4") |> pull(false_early_added)`** false alerts added beyond CDI
+- Best early:added ratio
 
-Raising to RP ≥ 5 drops 2021 and 2023 (recent droughts) without removing any false positives. Lowering to RP ≥ 3 adds one more drought (2022) but also five more false alerts, dropping the ratio to 1:1.
+Raising to RP ≥ 5 drops recent droughts (2021, 2023) without benefit. Lowering to RP ≥ 3 adds more false alerts that CDI wouldn't have triggered.
+:::
+
+## Understanding Model Errors
+
+Our F1-tuned CDI threshold triggers 11 years, capturing 9 of 10 ASI-defined droughts. The 3 "problem years" reveal important limitations:
+
+- **2 False Positives**: 2004, 2000 — CDI triggers but ASI says no drought
+- **1 False Negative**: 2007 — ASI says drought but CDI misses it
+
+```{r}
+#| label: fp-fn-analysis
+
+# Get probabilities from the fitted model
+prob_drought <- predict(final_ridge_fit, df_apr, type = "prob")$.pred_yes
+
+# Get ASI rankings from raw data
+df_apr_ranked <- blob_read(name = FEATURE_PATHS$april, container = "projects") |>
+    filter(!is.na(outcome_asi_zscore)) |>
+    arrange(desc(outcome_asi_zscore)) |>
+    mutate(asi_rank = row_number()) |>
+    select(pub_year, outcome_asi_zscore, asi_rank)
+
+df_analysis <- tibble(
+    year = df_apr$pub_year,
+    drought_actual = df_apr$drought,
+    prob = prob_drought
+) |>
+    mutate(
+        prob_rank = rank(-prob),
+        triggered = prob > best_prob_threshold,
+        status = case_when(
+            triggered & drought_actual == "yes" ~ "TP",
+            triggered & drought_actual == "no" ~ "FP",
+            !triggered & drought_actual == "yes" ~ "FN",
+            TRUE ~ "TN"
+        )
+    ) |>
+    left_join(df_apr_ranked, by = c("year" = "pub_year"))
+```
+
+```{r}
+#| label: fp-fn-table
+
+df_fp_fn <- df_analysis |>
+    filter(status %in% c("FP", "FN")) |>
+    arrange(status, desc(prob)) |>
+    select(year, status, prob, prob_rank, asi_rank, outcome_asi_zscore, drought_actual) |>
+    mutate(
+        prob = round(prob, 3),
+        outcome_asi_zscore = round(outcome_asi_zscore, 2)
+    )
+
+df_fp_fn |>
+    rename(
+        Year = year,
+        Status = status,
+        `CDI Prob` = prob,
+        `Prob Rank` = prob_rank,
+        `ASI Rank` = asi_rank,
+        `ASI Z-score` = outcome_asi_zscore,
+        `ASI Drought` = drought_actual
+    ) |>
+    gt() |>
+    tab_header(
+        title = "Model Errors: False Positives and False Negatives",
+        subtitle = "Comparing CDI probability rank vs ASI outcome rank"
+    ) |>
+    tab_style(
+        style = cell_fill(color = "tomato", alpha = 0.3),
+        locations = cells_body(rows = df_fp_fn$status == "FP")
+    ) |>
+    tab_style(
+        style = cell_fill(color = "steelblue", alpha = 0.3),
+        locations = cells_body(rows = df_fp_fn$status == "FN")
+    ) |>
+    tab_footnote(
+        footnote = "FP = False Positive (triggered, not drought) | FN = False Negative (missed drought)",
+        locations = cells_column_labels(columns = Status)
+    )
+```
+
+```{r}
+#| label: fp-fn-scatterplot
+#| fig-height: 6
+#| fig-width: 7
+
+df_analysis |>
+    ggplot(aes(x = asi_rank, y = prob_rank)) +
+    geom_abline(slope = 1, intercept = 0, linetype = "dashed", color = "grey50") +
+    geom_point(aes(color = status, size = status), alpha = 0.7) +
+    geom_text(
+        data = df_analysis |> filter(status %in% c("FP", "FN")),
+        aes(label = year),
+        hjust = -0.2, vjust = 0.5, size = 3
+    ) +
+    # Add reference lines for thresholds
+    geom_hline(yintercept = 11.5, linetype = "dotted", color = hdx_hex("sapphire-hdx")) +
+    geom_vline(xintercept = 10.5, linetype = "dotted", color = hdx_hex("tomato-hdx")) +
+    annotate("text", x = 42, y = 11.5, label = "CDI threshold",
+             hjust = 1, vjust = -0.5, size = 3, color = hdx_hex("sapphire-hdx")) +
+    annotate("text", x = 10.5, y = 42, label = "ASI threshold",
+             hjust = -0.1, vjust = 1, size = 3, color = hdx_hex("tomato-hdx"), angle = 90) +
+    scale_color_manual(
+        values = c("TP" = hdx_hex("mint-hdx"), "TN" = "grey70",
+                   "FP" = hdx_hex("tomato-hdx"), "FN" = hdx_hex("sapphire-hdx")),
+        labels = c("TP" = "True Positive", "TN" = "True Negative",
+                   "FP" = "False Positive", "FN" = "False Negative")
+    ) +
+    scale_size_manual(values = c("TP" = 3, "TN" = 2, "FP" = 5, "FN" = 5), guide = "none") +
+    scale_x_reverse() +
+    scale_y_reverse() +
+    labs(
+        title = "CDI Probability Rank vs ASI Outcome Rank",
+        subtitle = "Years in upper-left or lower-right quadrants are model errors",
+        x = "ASI Rank (1 = worst drought)",
+        y = "CDI Probability Rank (1 = highest prob)",
+        color = NULL
+    ) +
+    theme(legend.position = "bottom")
+```
+
+::: {.callout-note}
+## Interpretation
+
+**False Positives (2004, 2000)**: These years have indicator profiles that *look* like developing droughts in April, but the harvest-time ASI outcome was not severe. Possible explanations:
+
+- **2004** (ASI rank 12): Just missed the top-10 cutoff — borderline case
+- **2000** (ASI rank 15): Part of the 1999–2001 multi-year drought; single-year ASI may underestimate cumulative impact
+
+**False Negative (2007)**: ASI ranks it as drought (rank 5), but CDI gives it very low probability. This is the "2007 Anomaly" discussed below — likely caused by fallow fields from 2006 drought displacement distorting the signal.
+
+The scatterplot shows years on the diagonal are well-calibrated (ASI rank ≈ CDI rank). Off-diagonal years reveal where early indicators diverge from outcomes.
 :::
 
 ## The 2007 Anomaly {#sec-2007-anomaly}

--- a/book_afg_analysis/14_cerf_allocation_alignment.qmd
+++ b/book_afg_analysis/14_cerf_allocation_alignment.qmd
@@ -360,6 +360,129 @@ df_f1_by_rp |>
     )
 ```
 
+## Asymmetric RP Threshold Heatmap
+
+The plot above shows performance when both signals use the same RP threshold. But CDI and SEAS5 may have different optimal thresholds. The heatmap below explores all combinations, with marginal bar plots showing each signal's standalone performance.
+
+```{r}
+#| label: asymmetric-rp-grid
+
+# Compute F1 for all CDI × SEAS5 RP combinations
+df_asymmetric <- expand_grid(
+    cdi_rp_thresh = 2:7,
+    seas5_rp_thresh = 2:7
+) |>
+    pmap_dfr(function(cdi_rp_thresh, seas5_rp_thresh) {
+        combined_flag <- factor(
+            if_else(
+                df_cerf_analysis$cdi_rp >= cdi_rp_thresh |
+                df_cerf_analysis$seas5_rp >= seas5_rp_thresh,
+                "yes", "no"
+            ),
+            levels = c("yes", "no")
+        )
+
+        f1 <- yardstick::f_meas_vec(df_cerf_analysis$cerf, combined_flag)
+
+        tibble(
+            cdi_rp_thresh = cdi_rp_thresh,
+            seas5_rp_thresh = seas5_rp_thresh,
+            f1 = if_else(is.na(f1), 0, f1)
+        )
+    })
+
+# Marginal F1 for CDI alone
+df_cdi_marginal <- map_dfr(2:7, function(rp) {
+    flag <- factor(
+        if_else(df_cerf_analysis$cdi_rp >= rp, "yes", "no"),
+        levels = c("yes", "no")
+    )
+    f1 <- yardstick::f_meas_vec(df_cerf_analysis$cerf, flag)
+    tibble(rp = rp, f1 = if_else(is.na(f1), 0, f1))
+})
+
+# Marginal F1 for SEAS5 alone
+df_seas5_marginal <- map_dfr(2:7, function(rp) {
+    flag <- factor(
+        if_else(df_cerf_analysis$seas5_rp >= rp, "yes", "no"),
+        levels = c("yes", "no")
+    )
+    f1 <- yardstick::f_meas_vec(df_cerf_analysis$cerf, flag)
+    tibble(rp = rp, f1 = if_else(is.na(f1), 0, f1))
+})
+```
+
+```{r}
+#| label: asymmetric-heatmap-plot
+#| fig-height: 7
+#| fig-width: 8
+
+library(patchwork)
+
+# Main heatmap
+p_heat <- df_asymmetric |>
+    ggplot(aes(x = factor(cdi_rp_thresh), y = factor(seas5_rp_thresh), fill = f1)) +
+    geom_tile(color = "white", linewidth = 0.5) +
+    geom_text(aes(label = round(f1, 2)), size = 3.5, fontface = "bold") +
+    scale_fill_gradient2(
+        low = "white", mid = "khaki", high = hdx_hex("mint-hdx"),
+        midpoint = 0.4,
+        limits = c(0, max(df_asymmetric$f1)),
+        name = "F1"
+    ) +
+    labs(x = "CDI RP Threshold", y = "SEAS5 RP Threshold") +
+    theme(
+        panel.grid = element_blank(),
+        legend.position = "none"
+    )
+
+# Top marginal bar (CDI)
+p_top <- df_cdi_marginal |>
+    ggplot(aes(x = factor(rp), y = f1)) +
+    geom_col(fill = hdx_hex("sapphire-hdx"), width = 0.7) +
+    geom_text(aes(label = round(f1, 2)), vjust = -0.3, size = 3) +
+    scale_y_continuous(limits = c(0, max(df_cdi_marginal$f1) * 1.15), expand = c(0, 0)) +
+    labs(x = NULL, y = "F1", title = "CDI alone") +
+    theme(
+        axis.text.x = element_blank(),
+        axis.ticks.x = element_blank(),
+        panel.grid = element_blank()
+    )
+
+# Right marginal bar (SEAS5)
+p_right <- df_seas5_marginal |>
+    ggplot(aes(x = f1, y = factor(rp))) +
+    geom_col(fill = hdx_hex("tomato-hdx"), width = 0.7) +
+    geom_text(aes(label = round(f1, 2)), hjust = -0.2, size = 3) +
+    scale_x_continuous(limits = c(0, max(df_seas5_marginal$f1) * 1.15), expand = c(0, 0)) +
+    labs(x = "F1", y = NULL, title = "SEAS5 alone") +
+    theme(
+        axis.text.y = element_blank(),
+        axis.ticks.y = element_blank(),
+        panel.grid = element_blank()
+    )
+
+# Empty corner
+p_empty <- ggplot() + theme_void()
+
+# Combine with patchwork
+(p_top + p_empty + p_heat + p_right) +
+    plot_layout(
+        widths = c(4, 1),
+        heights = c(1, 4)
+    ) +
+    plot_annotation(
+        title = "Combined Trigger F1 (OR Logic) by RP Threshold",
+        subtitle = "Heatmap: combined | Top: CDI alone | Right: SEAS5 alone"
+    )
+```
+
+::: {.callout-note}
+## Interpretation
+
+The heatmap shows that **lowering the CDI threshold toward RP 3** improves CERF alignment regardless of SEAS5 threshold. This suggests CERF allocations respond to conditions that are somewhat less extreme than our ASI RP4 drought definition — humanitarian need is triggered by a broader range of conditions including conflict, food prices, and compounding factors beyond pure agricultural drought severity.
+:::
+
 ## Year-by-Year Alignment
 
 ```{r}

--- a/book_afg_analysis/14_cerf_allocation_alignment.qmd
+++ b/book_afg_analysis/14_cerf_allocation_alignment.qmd
@@ -433,7 +433,8 @@ p_heat <- df_asymmetric |>
     labs(x = "CDI RP Threshold", y = "SEAS5 RP Threshold") +
     theme(
         panel.grid = element_blank(),
-        legend.position = "none"
+        legend.position = "none",
+        plot.margin = margin(0, 0, 5, 5)
     )
 
 # Top marginal bar (CDI)
@@ -442,11 +443,15 @@ p_top <- df_cdi_marginal |>
     geom_col(fill = hdx_hex("sapphire-hdx"), width = 0.7) +
     geom_text(aes(label = round(f1, 2)), vjust = -0.3, size = 3) +
     scale_y_continuous(limits = c(0, max(df_cdi_marginal$f1) * 1.15), expand = c(0, 0)) +
-    labs(x = NULL, y = "F1", title = "CDI alone") +
+    labs(x = NULL, y = NULL, title = "CDI alone") +
     theme(
         axis.text.x = element_blank(),
         axis.ticks.x = element_blank(),
-        panel.grid = element_blank()
+        axis.text.y = element_blank(),
+        axis.ticks.y = element_blank(),
+        axis.line = element_blank(),
+        panel.grid = element_blank(),
+        plot.margin = margin(0, 0, -10, 0)
     )
 
 # Right marginal bar (SEAS5)
@@ -455,11 +460,15 @@ p_right <- df_seas5_marginal |>
     geom_col(fill = hdx_hex("tomato-hdx"), width = 0.7) +
     geom_text(aes(label = round(f1, 2)), hjust = -0.2, size = 3) +
     scale_x_continuous(limits = c(0, max(df_seas5_marginal$f1) * 1.15), expand = c(0, 0)) +
-    labs(x = "F1", y = NULL, title = "SEAS5 alone") +
+    labs(x = NULL, y = NULL, title = "SEAS5 alone") +
     theme(
+        axis.text.x = element_blank(),
+        axis.ticks.x = element_blank(),
         axis.text.y = element_blank(),
         axis.ticks.y = element_blank(),
-        panel.grid = element_blank()
+        axis.line = element_blank(),
+        panel.grid = element_blank(),
+        plot.margin = margin(0, 0, 0, -10)
     )
 
 # Empty corner
@@ -477,10 +486,80 @@ p_empty <- ggplot() + theme_void()
     )
 ```
 
+### Zoomed View: RP 3–5 Range
+
+The overview heatmap uses integer RP thresholds. The zoomed view below uses 0.1 increments to show exactly where our F1-tuned threshold (~RP 3.9) sits within the optimal range.
+
+```{r}
+#| label: zoomed-heatmap
+#| fig-height: 6
+#| fig-width: 7
+
+# Fine-grained RP breaks for zoom
+rp_fine <- seq(3, 5, by = 0.2)
+
+# Compute our tuned threshold's equivalent RP
+n_trigger_tuned <- sum(df_historical$prob_drought > best_prob_threshold)
+tuned_rp <- round((nrow(df_historical) + 1) / n_trigger_tuned, 1)
+
+df_zoom <- expand_grid(
+    cdi_rp_thresh = rp_fine,
+    seas5_rp_thresh = rp_fine
+) |>
+    pmap_dfr(function(cdi_rp_thresh, seas5_rp_thresh) {
+        combined_flag <- factor(
+            if_else(
+                df_cerf_analysis$cdi_rp >= cdi_rp_thresh |
+                df_cerf_analysis$seas5_rp >= seas5_rp_thresh,
+                "yes", "no"
+            ),
+            levels = c("yes", "no")
+        )
+        f1 <- yardstick::f_meas_vec(df_cerf_analysis$cerf, combined_flag)
+        tibble(
+            cdi_rp_thresh = cdi_rp_thresh,
+            seas5_rp_thresh = seas5_rp_thresh,
+            f1 = if_else(is.na(f1), 0, f1)
+        )
+    })
+
+# Find position of our tuned threshold (snap to nearest grid point)
+tuned_cdi_snap <- rp_fine[which.min(abs(rp_fine - tuned_rp))]
+
+df_zoom |>
+    ggplot(aes(x = factor(cdi_rp_thresh), y = factor(seas5_rp_thresh), fill = f1)) +
+    geom_tile(color = "white", linewidth = 0.3) +
+    geom_text(aes(label = round(f1, 2)), size = 2.5) +
+    # Highlight our tuned threshold
+    annotate("rect",
+             xmin = which(rp_fine == tuned_cdi_snap) - 0.5,
+             xmax = which(rp_fine == tuned_cdi_snap) + 0.5,
+             ymin = which(rp_fine == 4) - 0.5,
+             ymax = which(rp_fine == 4) + 0.5,
+             fill = NA, color = "black", linewidth = 1.5) +
+    scale_fill_gradient2(
+        low = "white", mid = "khaki", high = hdx_hex("mint-hdx"),
+        midpoint = 0.4,
+        limits = c(0, max(df_zoom$f1)),
+        name = "F1"
+    ) +
+    labs(
+        title = "Zoomed: Combined Trigger F1 (RP 3–5 range)",
+        subtitle = glue("Black border = proposed threshold (CDI ≈ RP {tuned_rp}, SEAS5 RP 4)"),
+        x = "CDI RP Threshold",
+        y = "SEAS5 RP Threshold"
+    ) +
+    theme(
+        panel.grid = element_blank(),
+        axis.text.x = element_text(size = 7, angle = 45, hjust = 1),
+        axis.text.y = element_text(size = 7)
+    )
+```
+
 ::: {.callout-note}
 ## Interpretation
 
-The heatmap shows that **lowering the CDI threshold toward RP 3** improves CERF alignment regardless of SEAS5 threshold. This suggests CERF allocations respond to conditions that are somewhat less extreme than our ASI RP4 drought definition — humanitarian need is triggered by a broader range of conditions including conflict, food prices, and compounding factors beyond pure agricultural drought severity.
+F1 peaks around RP 3–4 for both signals, declining at stricter thresholds (fewer triggers, more missed CERF years) or looser thresholds (more false positives). Our F1-tuned CDI threshold (~RP 3.9) falls within this optimal range. Within the CERF period, CDI at RP 4 catches 6 of 7 CERF allocation years — the only miss is 2012 (cdi_rp = 1.4), which would require an impractically low threshold to capture.
 :::
 
 ## Year-by-Year Alignment

--- a/book_afg_analysis/14_cerf_allocation_alignment.qmd
+++ b/book_afg_analysis/14_cerf_allocation_alignment.qmd
@@ -495,16 +495,17 @@ The overview heatmap uses integer RP thresholds. The zoomed view below uses 0.1 
 #| fig-height: 7
 #| fig-width: 8
 
-# Fine-grained RP breaks for zoom
-rp_fine <- seq(3, 5, by = 0.2)
+# Fine-grained RP breaks for CDI (3-5), extended range for SEAS5 (3-7)
+rp_cdi_fine <- seq(3, 5, by = 0.2)
+rp_seas5_fine <- c(seq(3, 5, by = 0.2), 6, 7)  # Fine 3-5, then 6, 7
 
 # Compute our tuned threshold's equivalent RP
 n_trigger_tuned <- sum(df_historical$prob_drought > best_prob_threshold)
 tuned_rp <- round((nrow(df_historical) + 1) / n_trigger_tuned, 1)
 
 df_zoom <- expand_grid(
-    cdi_rp_thresh = rp_fine,
-    seas5_rp_thresh = rp_fine
+    cdi_rp_thresh = rp_cdi_fine,
+    seas5_rp_thresh = rp_seas5_fine
 ) |>
     pmap_dfr(function(cdi_rp_thresh, seas5_rp_thresh) {
         combined_flag <- factor(
@@ -524,7 +525,7 @@ df_zoom <- expand_grid(
     })
 
 # Marginal F1 for CDI alone (zoomed range)
-df_cdi_zoom <- map_dfr(rp_fine, function(rp) {
+df_cdi_zoom <- map_dfr(rp_cdi_fine, function(rp) {
     flag <- factor(
         if_else(df_cerf_analysis$cdi_rp >= rp, "yes", "no"),
         levels = c("yes", "no")
@@ -533,8 +534,8 @@ df_cdi_zoom <- map_dfr(rp_fine, function(rp) {
     tibble(rp = rp, f1 = if_else(is.na(f1), 0, f1))
 })
 
-# Marginal F1 for SEAS5 alone (zoomed range)
-df_seas5_zoom <- map_dfr(rp_fine, function(rp) {
+# Marginal F1 for SEAS5 alone (extended range to 7)
+df_seas5_zoom <- map_dfr(rp_seas5_fine, function(rp) {
     flag <- factor(
         if_else(df_cerf_analysis$seas5_rp >= rp, "yes", "no"),
         levels = c("yes", "no")
@@ -544,7 +545,7 @@ df_seas5_zoom <- map_dfr(rp_fine, function(rp) {
 })
 
 # Find position of our tuned threshold (snap to nearest grid point)
-tuned_cdi_snap <- rp_fine[which.min(abs(rp_fine - tuned_rp))]
+tuned_cdi_snap <- rp_cdi_fine[which.min(abs(rp_cdi_fine - tuned_rp))]
 
 # Main heatmap
 p_heat_zoom <- df_zoom |>
@@ -553,10 +554,10 @@ p_heat_zoom <- df_zoom |>
     geom_text(aes(label = round(f1, 2)), size = 2.2) +
     # Highlight our tuned threshold
     annotate("rect",
-             xmin = which(rp_fine == tuned_cdi_snap) - 0.5,
-             xmax = which(rp_fine == tuned_cdi_snap) + 0.5,
-             ymin = which(rp_fine == 4) - 0.5,
-             ymax = which(rp_fine == 4) + 0.5,
+             xmin = which(rp_cdi_fine == tuned_cdi_snap) - 0.5,
+             xmax = which(rp_cdi_fine == tuned_cdi_snap) + 0.5,
+             ymin = which(rp_seas5_fine == 4) - 0.5,
+             ymax = which(rp_seas5_fine == 4) + 0.5,
              fill = NA, color = "black", linewidth = 1.5) +
     scale_fill_gradient2(
         low = "white", mid = "khaki", high = hdx_hex("mint-hdx"),
@@ -617,7 +618,7 @@ p_empty_zoom <- ggplot() + theme_void()
         heights = c(1, 4)
     ) +
     plot_annotation(
-        title = "Zoomed: Combined Trigger F1 (RP 3–5 range)",
+        title = "Combined Trigger F1: CDI (3–5) × SEAS5 (3–7)",
         subtitle = glue("Black border = proposed threshold (CDI ≈ RP {tuned_rp}, SEAS5 RP 4)")
     )
 ```
@@ -689,4 +690,300 @@ df_cerf_analysis |>
 ## Interpretation
 
 CERF Rapid Response allocations and ASI-defined droughts overlap substantially but are not identical — CERF reflects humanitarian decision-making which incorporates factors beyond meteorological drought (e.g., conflict, food prices, displacement). Years where the trigger aligns with CERF but not ASI (or vice versa) highlight where the two framings diverge. Underfunded Emergencies allocations (2008, 2010) are excluded as they represent a different funding mechanism with different triggering criteria.
+:::
+
+## Validation Framework & Limitations
+
+This section documents the validation logic underlying the trigger system and acknowledges remaining gaps.
+
+### The Validation Chain
+
+The trigger system involves multiple layers of proxy variables:
+
+```
+Humanitarian Impact    ←  External Validation  ←  Training Target   ←  Early Warning
+(food insecurity,         (CERF allocations)       (ASI RP ≥ 4)         (CDI, SEAS5)
+displacement, etc.)
+```
+
+**Key validation finding**: The CDI, which was trained to predict ASI RP ≥ 4 events, also achieves **ROC-AUC = `r round(roc_cdi, 3)`** against CERF Rapid Response allocations. This strong discriminative ability against an *independent* outcome variable provides evidence that:
+1. ASI RP ≥ 4 is a reasonable proxy for "drought severe enough to warrant humanitarian response"
+2. The CDI learned genuine drought signals, not just ASI-specific artifacts
+3. Early-season indicators (precipitation, soil moisture, snow cover, vegetation) contain predictive information about end-of-season humanitarian outcomes
+
+### Why ASI RP ≥ 4?
+
+The choice of ASI at RP ≥ 4 as the training target reflects several considerations:
+
+1. **ASI as outcome proxy**: The FAO Agricultural Stress Index measures vegetation health anomalies during the growing season. For agricultural livelihoods, reduced vegetation correlates with crop failure and food insecurity.
+
+2. **RP ≥ 4 threshold**: A 4-year return period means "worse than 1 in 4 years" — approximately the worst 25% of years. This threshold:
+   - Aligns with typical anticipatory action activation frequencies (every 3-5 years)
+   - Is severe enough to warrant early action
+   - Provides sufficient positive cases for model training (10/42 years)
+
+3. **End-of-season timing**: June ASI captures the cumulative growing season outcome, providing the "answer" that early-season indicators are trying to predict.
+
+### External Validation via CERF
+
+CERF Rapid Response allocations serve as external validation because:
+
+- **Independent decision**: CERF allocations reflect real-time humanitarian assessments, not ASI values
+- **Action-relevant**: Allocations indicate droughts severe enough to trigger international funding
+- **Comparable timing**: Rapid Response targets acute emergencies analogous to anticipatory action
+
+The strong CDI-CERF alignment (AUC = `r round(roc_cdi, 3)`) suggests that ASI RP ≥ 4 years do correspond to droughts that warranted humanitarian response historically.
+
+### Remaining Gaps
+
+The validation framework has limitations that should be acknowledged:
+
+1. **No direct outcome data**: Ideally, we would validate against:
+   - IPC food insecurity classifications
+   - Crop production statistics
+   - Household survey data on food consumption
+   - Displacement figures
+
+2. **CERF is imperfect ground truth**: CERF allocations depend on:
+   - Funding availability
+   - Competing emergencies globally
+   - Quality of country-level appeals
+   - Political factors
+
+3. **Small sample sizes**: Only 5 CERF drought allocations in 20 years limits statistical power for CERF-based evaluation.
+
+4. **Spatial aggregation**: The trigger operates at a 5-province merged level, which may mask within-region heterogeneity.
+
+5. **Conflict confounding**: Afghanistan's ongoing conflict affects both drought impacts and humanitarian response, making it difficult to isolate drought-specific effects.
+
+::: {.callout-important}
+## Bottom Line
+
+The trigger system is validated at multiple levels:
+
+- **Internal**: CDI achieves F1 ~0.82 against ASI RP ≥ 4 (LOOCV)
+- **External**: CDI achieves AUC = `r round(roc_cdi, 3)` against CERF allocations
+
+This provides reasonable confidence that the trigger captures "real" droughts worth acting on. However, direct validation against food security outcomes remains a gap that could strengthen the evidence base for future iterations.
+:::
+
+## Appendix: RP Threshold Sensitivity
+
+A key modeling choice is defining "drought" as ASI RP ≥ 4. This appendix tests whether RP 3 or RP 5 would produce better CERF alignment.
+
+```{r}
+#| label: rp-sensitivity-setup
+
+# Function to fit model and evaluate CERF alignment for a given RP threshold
+fit_and_evaluate <- function(rp_threshold, df_apr_raw, df_cerf_yr) {
+
+    # Prepare data with this RP threshold
+    df <- df_apr_raw |>
+        filter(!is.na(outcome_asi_zscore)) |>
+        arrange(desc(outcome_asi_zscore)) |>
+        mutate(
+            rank = row_number(),
+            q_rank = rank / (n() + 1),
+            rp_emp = 1 / q_rank,
+            drought = factor(
+                if_else(rp_emp >= rp_threshold, "yes", "no"),
+                levels = c("yes", "no")
+            )
+        )
+
+    n_drought_years <- sum(df$drought == "yes")
+
+    # Fit ridge model
+    df_model <- df |>
+        select(-outcome_asi_zscore, -rank, -q_rank, -rp_emp,
+               -starts_with("adm0_name"), -pub_date, -timestep)
+
+    recipe_spec <- recipe(drought ~ ., data = df_model) |>
+        step_rm(all_of(c("pub_year", APRIL_EXCLUDE_VARS, "precip_cumsum"))) |>
+        step_zv(all_predictors())
+
+    ridge_spec <- logistic_reg(penalty = tune(), mixture = 0) |>
+        set_engine("glmnet") |>
+        set_mode("classification")
+
+    wf <- workflow() |>
+        add_recipe(recipe_spec) |>
+        add_model(ridge_spec)
+
+    set.seed(SEED)
+    boots <- bootstraps(df_model, times = 15, strata = drought)
+    grid <- grid_regular(penalty(range = c(-4, 0)), levels = 20)
+
+    tune_res <- tune_grid(wf, resamples = boots, grid = grid,
+                          metrics = metric_set(f_meas),
+                          control = control_grid(save_pred = FALSE, verbose = FALSE))
+
+    best_pen <- select_best(tune_res, metric = "f_meas")
+    final_fit <- fit(finalize_workflow(wf, best_pen), data = df_model)
+
+    # Get CDI weights and threshold
+    coefs <- final_fit |>
+        extract_fit_parsnip() |>
+        tidy() |>
+        filter(term != "(Intercept)")
+
+    weights <- coefs |>
+        mutate(weight = -estimate / sum(abs(estimate)))
+
+    # Calculate CDI
+    calc_cdi_local <- function(data, weights_df) {
+        cdi <- rep(0, nrow(data))
+        for (i in seq_len(nrow(weights_df))) {
+            feat <- weights_df$term[i]
+            w <- weights_df$weight[i]
+            if (feat %in% colnames(data)) {
+                cdi <- cdi + w * data[[feat]]
+            }
+        }
+        cdi
+    }
+
+    cdi_vals <- calc_cdi_local(df_model, weights)
+    prob_drought <- predict(final_fit, df_model, type = "prob")$.pred_yes
+
+    # F1-optimized threshold
+    thresholds <- seq(0.1, 0.9, by = 0.05)
+    best_thresh <- map_dfr(thresholds, function(t) {
+        pred <- factor(if_else(prob_drought > t, "yes", "no"), levels = c("yes", "no"))
+        tibble(threshold = t, f1 = yardstick::f_meas_vec(df_model$drought, pred))
+    }) |>
+        filter(f1 == max(f1, na.rm = TRUE)) |>
+        slice(1) |>
+        pull(threshold)
+
+    cdi_threshold <- min(cdi_vals[prob_drought > best_thresh])
+
+    # Build historical for CERF analysis
+    df_hist <- tibble(
+        year = df$pub_year,
+        cdi = cdi_vals
+    ) |>
+        mutate(cdi_rp = rp_empirical(cdi, direction = "-1"))
+
+    # Join with CERF
+    df_cerf_eval <- df_hist |>
+        inner_join(df_cerf_yr, by = c("year" = "yr"))
+
+    # Evaluate CERF alignment
+    cdi_flag <- factor(
+        if_else(df_cerf_eval$cdi >= cdi_threshold, "yes", "no"),
+        levels = c("yes", "no")
+    )
+
+    cerf_f1 <- yardstick::f_meas_vec(df_cerf_eval$cerf, cdi_flag)
+    cerf_auc <- yardstick::roc_auc_vec(df_cerf_eval$cerf, df_cerf_eval$cdi)
+    cerf_precision <- yardstick::precision_vec(df_cerf_eval$cerf, cdi_flag)
+    cerf_recall <- yardstick::recall_vec(df_cerf_eval$cerf, cdi_flag)
+
+    # Years that trigger
+    trigger_years <- df_cerf_eval$year[df_cerf_eval$cdi >= cdi_threshold]
+
+    tibble(
+        rp_threshold = rp_threshold,
+        n_drought_years = n_drought_years,
+        cerf_auc = cerf_auc,
+        cerf_f1 = cerf_f1,
+        cerf_precision = cerf_precision,
+        cerf_recall = cerf_recall,
+        trigger_years = list(trigger_years)
+    )
+}
+
+# Run for RP 3, 4, 5
+df_rp_sensitivity <- map_dfr(c(3, 4, 5), function(rp) {
+    fit_and_evaluate(rp, df_apr_raw, df_cerf_yr)
+})
+```
+
+### CERF Alignment by Training RP
+
+```{r}
+#| label: rp-sensitivity-table
+
+df_rp_sensitivity |>
+    select(rp_threshold, n_drought_years, cerf_auc, cerf_f1, cerf_precision, cerf_recall) |>
+    gt() |>
+    tab_header(
+        title = "CERF Alignment by ASI RP Training Threshold",
+        subtitle = "How does the choice of 'drought' definition affect CERF prediction?"
+    ) |>
+    cols_label(
+        rp_threshold = "Training RP",
+        n_drought_years = "Drought Years",
+        cerf_auc = "AUC",
+        cerf_f1 = "F1",
+        cerf_precision = "Precision",
+        cerf_recall = "Recall"
+    ) |>
+    fmt_number(columns = c(cerf_auc, cerf_f1, cerf_precision, cerf_recall), decimals = 3) |>
+    tab_style(
+        style = cell_fill(color = "lightgreen"),
+        locations = cells_body(rows = rp_threshold == 4)
+    ) |>
+    tab_footnote(
+        footnote = "Green = current choice (RP ≥ 4)",
+        locations = cells_column_labels(columns = rp_threshold)
+    )
+```
+
+### Which Years Trigger Under Each Threshold?
+
+```{r}
+#| label: rp-sensitivity-years
+
+# Extract trigger years for comparison
+trigger_rp3 <- df_rp_sensitivity |> filter(rp_threshold == 3) |> pull(trigger_years) |> unlist()
+trigger_rp4 <- df_rp_sensitivity |> filter(rp_threshold == 4) |> pull(trigger_years) |> unlist()
+trigger_rp5 <- df_rp_sensitivity |> filter(rp_threshold == 5) |> pull(trigger_years) |> unlist()
+
+# Build comparison table
+all_years <- sort(unique(c(trigger_rp3, trigger_rp4, trigger_rp5)))
+
+tibble(
+    year = all_years,
+    rp3 = if_else(all_years %in% trigger_rp3, "✓", ""),
+    rp4 = if_else(all_years %in% trigger_rp4, "✓", ""),
+    rp5 = if_else(all_years %in% trigger_rp5, "✓", ""),
+    cerf = if_else(all_years %in% (df_cerf_yr |> filter(cerf == "yes") |> pull(yr)), "✓", "")
+) |>
+    arrange(desc(year)) |>
+    gt() |>
+    tab_header(
+        title = "Trigger Years by Training RP Threshold",
+        subtitle = "Which years fire under each definition of 'drought'?"
+    ) |>
+    cols_label(
+        year = "Year",
+        rp3 = "RP ≥ 3",
+        rp4 = "RP ≥ 4",
+        rp5 = "RP ≥ 5",
+        cerf = "CERF"
+    ) |>
+    tab_style(
+        style = cell_fill(color = "tomato", alpha = 0.3),
+        locations = cells_body(columns = cerf, rows = cerf == "✓")
+    ) |>
+    tab_spanner(label = "Training Threshold", columns = c(rp3, rp4, rp5))
+```
+
+::: {.callout-note}
+## RP Sensitivity Findings
+
+The choice of RP threshold for defining "drought" affects:
+
+1. **Number of positive training examples**: RP 3 includes more years (~14), RP 5 fewer (~8)
+2. **CERF alignment**: All three thresholds produce similar AUC/F1, suggesting the CDI learns robust drought signals regardless of exact threshold
+3. **Trigger years**: The core drought years (major CERF allocations) are captured at all thresholds; differences occur at the margins
+
+**Why RP 4?**
+
+- Provides balanced class sizes for training (10/42 years)
+- Aligns with typical AA activation frequencies (every 3-5 years)
+- Performance is robust: nearby thresholds (RP 3, RP 5) yield similar CERF alignment
+- The "plateau" in CERF F1 across RP 3-5 indicates we're in a stable operating region
 :::

--- a/book_afg_analysis/14_cerf_allocation_alignment.qmd
+++ b/book_afg_analysis/14_cerf_allocation_alignment.qmd
@@ -1,0 +1,409 @@
+---
+title: "CERF Allocation Alignment"
+format:
+  html:
+    toc: true
+    toc-depth: 3
+    code-fold: true
+execute:
+  warning: false
+  message: false
+project:
+  execute-dir: project
+---
+
+## Introduction
+
+This chapter evaluates how well the proposed trigger signals align with **historical CERF Rapid Response drought allocations** for Afghanistan. CERF Rapid Response allocations represent an independent, external validation of drought severity — they reflect the humanitarian community's real-time assessment that conditions warranted emergency funding.
+
+We filter to **Rapid Response** allocations only (excluding Underfunded Emergencies), as these represent the acute drought response most analogous to anticipatory action triggers. We treat CERF Rapid Response allocation as the outcome variable and ask: if we had applied our CDI or SEAS5 triggers historically, how often would they have correctly predicted a CERF allocation year?
+
+```{r}
+#| label: setup
+
+box::use(
+    dplyr[...],
+    tidyr[...],
+    ggplot2[...],
+    gghdx[...],
+    cumulus[...],
+    purrr[...],
+    glue[glue],
+    tibble[tibble],
+    janitor[clean_names],
+    lubridate[year, as_date]
+)
+
+library(tidymodels)
+library(gt)
+gghdx()
+```
+
+```{r}
+#| label: config
+
+RP_THRESHOLD <- 4
+SEED <- 42
+N_BOOTSTRAP <- 30
+
+FEATURE_PATHS <- list(
+    march = "ds-aa-afg-drought/processed/vector/2026_mar_pub_feature_set_v1.parquet",
+    april = "ds-aa-afg-drought/processed/vector/2026_april_pub_feature_set_v1.parquet"
+)
+
+APRIL_EXCLUDE_VARS <- c("total_precipitation_sum", "seas5 Apr", "seas5 May")
+```
+
+## Data
+
+```{r}
+#| label: load-data
+
+# Load feature sets
+df_mar_raw <- blob_read(name = FEATURE_PATHS$march, container = "projects")
+df_apr_raw <- blob_read(name = FEATURE_PATHS$april, container = "projects")
+
+# Prepare modeling data
+prepare_model_data <- function(df, rp_threshold = RP_THRESHOLD) {
+    df |>
+        filter(!is.na(outcome_asi_zscore)) |>
+        arrange(desc(outcome_asi_zscore)) |>
+        mutate(
+            rank = row_number(),
+            q_rank = rank / (n() + 1),
+            rp_emp = 1 / q_rank,
+            drought = factor(
+                if_else(rp_emp >= rp_threshold, "yes", "no"),
+                levels = c("yes", "no")
+            )
+        ) |>
+        select(-outcome_asi_zscore, -rank, -q_rank, -rp_emp,
+               -starts_with("adm0_name"), -pub_date, -timestep)
+}
+
+df_mar <- prepare_model_data(df_mar_raw)
+df_apr <- prepare_model_data(df_apr_raw)
+```
+
+```{r}
+#| label: fit-ridge
+
+ridge_spec <- logistic_reg(penalty = tune(), mixture = 0) |>
+    set_engine("glmnet") |>
+    set_mode("classification")
+
+ridge_recipe <- recipe(drought ~ ., data = df_apr) |>
+    step_rm(all_of(c("pub_year", APRIL_EXCLUDE_VARS, "precip_cumsum"))) |>
+    step_zv(all_predictors())
+
+ridge_wf <- workflow() |>
+    add_recipe(ridge_recipe) |>
+    add_model(ridge_spec)
+
+set.seed(SEED)
+ridge_boots <- bootstraps(df_apr, times = N_BOOTSTRAP, strata = drought)
+penalty_grid <- grid_regular(penalty(range = c(-4, 0)), levels = 30)
+
+ridge_tune <- tune_grid(
+    ridge_wf,
+    resamples = ridge_boots,
+    grid = penalty_grid,
+    metrics = metric_set(roc_auc, f_meas),
+    control = control_grid(save_pred = TRUE)
+)
+
+best_penalty <- select_best(ridge_tune, metric = "f_meas")
+final_ridge_fit <- fit(finalize_workflow(ridge_wf, best_penalty), data = df_apr)
+
+coefs_ridge <- final_ridge_fit |>
+    extract_fit_parsnip() |>
+    tidy() |>
+    filter(term != "(Intercept)")
+
+cdi_weights <- coefs_ridge |>
+    mutate(
+        weight = -estimate / sum(abs(estimate)),
+        contribution_pct = abs(weight) * 100
+    ) |>
+    arrange(desc(contribution_pct)) |>
+    select(term, estimate, weight, contribution_pct)
+```
+
+```{r}
+#| label: load-cerf
+
+df_cerf <- blob_read("ds-aa-afg-drought/raw/vector/afg_drought_cerf_allocations.xlsx") |>
+    clean_names() |>
+    mutate(allocation_date = as_date(allocation_date)) |>
+    filter(window == "Rapid Response")
+
+df_cerf_yr <- df_cerf |>
+    group_by(yr = year(allocation_date)) |>
+    summarise(n_allocations = n()) |>
+    # 2025 CERF Rapid Response allocation occurred but is not yet in the dataset
+    bind_rows(tibble(yr = 2025, n_allocations = 1)) |>
+    complete(yr = 2006:2025, fill = list(n_allocations = 0)) |>
+    mutate(cerf = factor(if_else(n_allocations > 0, "yes", "no"), levels = c("yes", "no")))
+```
+
+```{r}
+#| label: build-historical
+
+calc_cdi <- function(data, weights_df) {
+    cdi <- rep(0, nrow(data))
+    for (i in seq_len(nrow(weights_df))) {
+        feat <- weights_df$term[i]
+        w <- weights_df$weight[i]
+        if (feat %in% colnames(data)) {
+            cdi <- cdi + w * data[[feat]]
+        }
+    }
+    cdi
+}
+
+rp_empirical <- function(x) {
+    r <- rank(-x, ties.method = "average")
+    q <- r / (length(x) + 1)
+    1 / q
+}
+
+df_historical <- tibble(
+    year = df_apr$pub_year,
+    drought_actual = df_apr$drought,
+    cdi = calc_cdi(df_apr, cdi_weights),
+    seas5_mam = df_mar$`seas5 Mar-Apr-May`
+) |>
+    mutate(
+        cdi_rp = rp_empirical(cdi),
+        seas5_rp = rp_empirical(seas5_mam)
+    )
+
+# Join with CERF data — restrict to CERF coverage period (2006–2024)
+df_cerf_analysis <- df_historical |>
+    inner_join(df_cerf_yr, by = c("year" = "yr"))
+```
+
+**CERF allocation years**: `r paste(df_cerf_yr |> filter(cerf == "yes") |> pull(yr), collapse = ", ")`.
+
+Analysis period: `r min(df_cerf_analysis$year)`–`r max(df_cerf_analysis$year)` (`r nrow(df_cerf_analysis)` years), of which `r sum(df_cerf_analysis$cerf == "yes")` had CERF drought allocations.
+
+## ROC-AUC: Continuous Signal Quality
+
+Before examining thresholds, we evaluate how well the **continuous** CDI and SEAS5 scores discriminate CERF allocation years from non-allocation years. ROC-AUC is threshold-independent and measures overall ranking quality.
+
+```{r}
+#| label: roc-auc
+
+roc_cdi <- yardstick::roc_auc_vec(
+    df_cerf_analysis$cerf,
+    df_cerf_analysis$cdi
+)
+
+roc_seas5 <- yardstick::roc_auc_vec(
+    df_cerf_analysis$cerf,
+    df_cerf_analysis$seas5_mam
+)
+
+tibble(
+    Signal = c("CDI (April)", "SEAS5 MAM (March)"),
+    `ROC-AUC` = c(roc_cdi, roc_seas5)
+) |>
+    gt() |>
+    tab_header(
+        title = "ROC-AUC: Continuous Signal vs CERF Allocation",
+        subtitle = glue("{min(df_cerf_analysis$year)}\u2013{max(df_cerf_analysis$year)}")
+    ) |>
+    fmt_number(columns = `ROC-AUC`, decimals = 3)
+```
+
+```{r}
+#| label: roc-curves
+#| fig-height: 5
+#| fig-width: 7
+
+roc_data_cdi <- yardstick::roc_curve(
+    df_cerf_analysis |> mutate(cerf = factor(cerf, levels = c("yes", "no"))),
+    cerf,
+    cdi
+) |> mutate(signal = "CDI (April)")
+
+roc_data_seas5 <- yardstick::roc_curve(
+    df_cerf_analysis |> mutate(cerf = factor(cerf, levels = c("yes", "no"))),
+    cerf,
+    seas5_mam
+) |> mutate(signal = "SEAS5 MAM (March)")
+
+bind_rows(roc_data_cdi, roc_data_seas5) |>
+    ggplot(aes(x = 1 - specificity, y = sensitivity, color = signal)) +
+    geom_path(linewidth = 1.2) +
+    geom_abline(linetype = "dashed", color = "grey50") +
+    scale_color_manual(values = c(
+        "CDI (April)" = hdx_hex("sapphire-hdx"),
+        "SEAS5 MAM (March)" = hdx_hex("tomato-hdx")
+    )) +
+    labs(
+        title = "ROC Curves: Trigger Signals vs CERF Allocation",
+        subtitle = glue("CDI AUC = {round(roc_cdi, 3)} | SEAS5 AUC = {round(roc_seas5, 3)}"),
+        x = "False Positive Rate (1 - Specificity)",
+        y = "True Positive Rate (Sensitivity)",
+        color = NULL
+    )
+```
+
+## F1 by RP Threshold
+
+For each RP threshold (1–7), we flag years where CDI or SEAS5 exceeds the threshold and compute classification metrics against CERF allocation.
+
+```{r}
+#| label: f1-by-threshold
+
+df_f1_by_rp <- map_dfr(1:7, function(rp) {
+    cdi_flag <- factor(
+        if_else(df_cerf_analysis$cdi_rp >= rp, "yes", "no"),
+        levels = c("yes", "no")
+    )
+    seas5_flag <- factor(
+        if_else(df_cerf_analysis$seas5_rp >= rp, "yes", "no"),
+        levels = c("yes", "no")
+    )
+    combined_flag <- factor(
+        if_else(df_cerf_analysis$cdi_rp >= rp | df_cerf_analysis$seas5_rp >= rp, "yes", "no"),
+        levels = c("yes", "no")
+    )
+
+    cerf_truth <- df_cerf_analysis$cerf
+
+    calc_metrics <- function(pred, label) {
+        tibble(
+            signal = label,
+            rp = rp,
+            f1 = yardstick::f_meas_vec(cerf_truth, pred),
+            precision = yardstick::precision_vec(cerf_truth, pred),
+            recall = yardstick::recall_vec(cerf_truth, pred)
+        )
+    }
+
+    bind_rows(
+        calc_metrics(cdi_flag, "CDI (April)"),
+        calc_metrics(seas5_flag, "SEAS5 (March)"),
+        calc_metrics(combined_flag, "Combined OR")
+    )
+})
+```
+
+```{r}
+#| label: f1-by-threshold-plot
+#| fig-height: 5
+#| fig-width: 8
+
+df_f1_by_rp |>
+    ggplot(aes(x = rp, y = f1, color = signal)) +
+    geom_line(linewidth = 1.2) +
+    geom_point(size = 3) +
+    scale_x_continuous(breaks = 1:7) +
+    scale_color_manual(values = c(
+        "CDI (April)" = hdx_hex("sapphire-hdx"),
+        "SEAS5 (March)" = hdx_hex("tomato-hdx"),
+        "Combined OR" = hdx_hex("mint-hdx")
+    )) +
+    labs(
+        title = "How Well Do Different RP Thresholds Predict CERF Allocation?",
+        subtitle = glue("Merged 5-province area | {min(df_cerf_analysis$year)}\u2013{max(df_cerf_analysis$year)}"),
+        x = "RP Threshold",
+        y = "F1 Score",
+        color = NULL
+    )
+```
+
+```{r}
+#| label: f1-threshold-table
+
+df_f1_by_rp |>
+    filter(rp %in% 2:6) |>
+    mutate(across(c(f1, precision, recall), \(x) round(x, 3))) |>
+    pivot_wider(
+        names_from = signal,
+        values_from = c(f1, precision, recall),
+        names_glue = "{signal}_{.value}"
+    ) |>
+    select(rp, starts_with("CDI"), starts_with("SEAS5"), starts_with("Combined")) |>
+    gt() |>
+    tab_header(
+        title = "Classification Metrics by RP Threshold",
+        subtitle = "CERF allocation as outcome"
+    ) |>
+    tab_spanner(label = "CDI (April)", columns = starts_with("CDI")) |>
+    tab_spanner(label = "SEAS5 (March)", columns = starts_with("SEAS5")) |>
+    tab_spanner(label = "Combined OR", columns = starts_with("Combined")) |>
+    cols_label(
+        rp = "RP",
+        `CDI (April)_f1` = "F1",
+        `CDI (April)_precision` = "Prec",
+        `CDI (April)_recall` = "Rec",
+        `SEAS5 (March)_f1` = "F1",
+        `SEAS5 (March)_precision` = "Prec",
+        `SEAS5 (March)_recall` = "Rec",
+        `Combined OR_f1` = "F1",
+        `Combined OR_precision` = "Prec",
+        `Combined OR_recall` = "Rec"
+    )
+```
+
+## Year-by-Year Alignment
+
+```{r}
+#| label: cerf-alignment-table
+
+df_cerf_analysis |>
+    mutate(
+        cdi_rp4 = if_else(cdi_rp >= 4, "yes", "no"),
+        seas5_rp4 = if_else(seas5_rp >= 4, "yes", "no"),
+        combined = if_else(cdi_rp >= 4 | seas5_rp >= 4, "yes", "no")
+    ) |>
+    select(year, cerf, drought_actual, cdi_rp4, seas5_rp4, combined) |>
+    arrange(desc(year)) |>
+    rename(
+        Year = year,
+        CERF = cerf,
+        `ASI Drought` = drought_actual,
+        `CDI RP4` = cdi_rp4,
+        `SEAS5 RP4` = seas5_rp4,
+        `Combined` = combined
+    ) |>
+    gt() |>
+    tab_header(
+        title = "Year-by-Year: Trigger Decisions vs CERF Allocations",
+        subtitle = glue("{min(df_cerf_analysis$year)}\u2013{max(df_cerf_analysis$year)}")
+    ) |>
+    tab_style(
+        style = cell_fill(color = "tomato", alpha = 0.4),
+        locations = cells_body(columns = CERF, rows = CERF == "yes")
+    ) |>
+    tab_style(
+        style = cell_fill(color = "gold", alpha = 0.3),
+        locations = cells_body(columns = `ASI Drought`, rows = `ASI Drought` == "yes")
+    ) |>
+    tab_style(
+        style = cell_fill(color = "steelblue", alpha = 0.4),
+        locations = cells_body(columns = `CDI RP4`, rows = `CDI RP4` == "yes")
+    ) |>
+    tab_style(
+        style = cell_fill(color = "steelblue", alpha = 0.4),
+        locations = cells_body(columns = `SEAS5 RP4`, rows = `SEAS5 RP4` == "yes")
+    ) |>
+    tab_style(
+        style = cell_fill(color = "steelblue", alpha = 0.4),
+        locations = cells_body(columns = Combined, rows = Combined == "yes")
+    ) |>
+    tab_spanner(label = "Trigger (RP4)", columns = c(`CDI RP4`, `SEAS5 RP4`, `Combined`)) |>
+    tab_footnote(
+        footnote = "Red = CERF allocation | Gold = ASI drought | Blue = trigger fires",
+        locations = cells_column_spanners()
+    )
+```
+
+::: {.callout-note}
+## Interpretation
+
+CERF Rapid Response allocations and ASI-defined droughts overlap substantially but are not identical — CERF reflects humanitarian decision-making which incorporates factors beyond meteorological drought (e.g., conflict, food prices, displacement). Years where the trigger aligns with CERF but not ASI (or vice versa) highlight where the two framings diverge. Underfunded Emergencies allocations (2008, 2010) are excluded as they represent a different funding mechanism with different triggering criteria.
+:::

--- a/book_afg_analysis/14_cerf_allocation_alignment.qmd
+++ b/book_afg_analysis/14_cerf_allocation_alignment.qmd
@@ -263,12 +263,12 @@ bind_rows(roc_data_cdi, roc_data_seas5) |>
 
 ## F1 by RP Threshold
 
-For each RP threshold (1–7), we flag years where CDI or SEAS5 exceeds the threshold and compute classification metrics against CERF allocation.
+For each RP threshold, we flag years where CDI or SEAS5 exceeds the threshold and compute classification metrics against CERF allocation.
 
 ```{r}
 #| label: f1-by-threshold
 
-df_f1_by_rp <- map_dfr(1:7, function(rp) {
+df_f1_by_rp <- map_dfr(seq(1, 7, by = 0.1), function(rp) {
     cdi_flag <- factor(
         if_else(df_cerf_analysis$cdi_rp >= rp, "yes", "no"),
         levels = c("yes", "no")
@@ -309,8 +309,8 @@ df_f1_by_rp <- map_dfr(1:7, function(rp) {
 
 df_f1_by_rp |>
     ggplot(aes(x = rp, y = f1, color = signal)) +
-    geom_line(linewidth = 1.2) +
-    geom_point(size = 3) +
+    geom_line(linewidth = 0.8) +
+    geom_point(size = 1) +
     scale_x_continuous(breaks = 1:7) +
     scale_color_manual(values = c(
         "CDI (April)" = hdx_hex("sapphire-hdx"),
@@ -492,8 +492,8 @@ The overview heatmap uses integer RP thresholds. The zoomed view below uses 0.1 
 
 ```{r}
 #| label: zoomed-heatmap
-#| fig-height: 6
-#| fig-width: 7
+#| fig-height: 7
+#| fig-width: 8
 
 # Fine-grained RP breaks for zoom
 rp_fine <- seq(3, 5, by = 0.2)
@@ -523,13 +523,34 @@ df_zoom <- expand_grid(
         )
     })
 
+# Marginal F1 for CDI alone (zoomed range)
+df_cdi_zoom <- map_dfr(rp_fine, function(rp) {
+    flag <- factor(
+        if_else(df_cerf_analysis$cdi_rp >= rp, "yes", "no"),
+        levels = c("yes", "no")
+    )
+    f1 <- yardstick::f_meas_vec(df_cerf_analysis$cerf, flag)
+    tibble(rp = rp, f1 = if_else(is.na(f1), 0, f1))
+})
+
+# Marginal F1 for SEAS5 alone (zoomed range)
+df_seas5_zoom <- map_dfr(rp_fine, function(rp) {
+    flag <- factor(
+        if_else(df_cerf_analysis$seas5_rp >= rp, "yes", "no"),
+        levels = c("yes", "no")
+    )
+    f1 <- yardstick::f_meas_vec(df_cerf_analysis$cerf, flag)
+    tibble(rp = rp, f1 = if_else(is.na(f1), 0, f1))
+})
+
 # Find position of our tuned threshold (snap to nearest grid point)
 tuned_cdi_snap <- rp_fine[which.min(abs(rp_fine - tuned_rp))]
 
-df_zoom |>
+# Main heatmap
+p_heat_zoom <- df_zoom |>
     ggplot(aes(x = factor(cdi_rp_thresh), y = factor(seas5_rp_thresh), fill = f1)) +
     geom_tile(color = "white", linewidth = 0.3) +
-    geom_text(aes(label = round(f1, 2)), size = 2.5) +
+    geom_text(aes(label = round(f1, 2)), size = 2.2) +
     # Highlight our tuned threshold
     annotate("rect",
              xmin = which(rp_fine == tuned_cdi_snap) - 0.5,
@@ -543,23 +564,72 @@ df_zoom |>
         limits = c(0, max(df_zoom$f1)),
         name = "F1"
     ) +
-    labs(
-        title = "Zoomed: Combined Trigger F1 (RP 3–5 range)",
-        subtitle = glue("Black border = proposed threshold (CDI ≈ RP {tuned_rp}, SEAS5 RP 4)"),
-        x = "CDI RP Threshold",
-        y = "SEAS5 RP Threshold"
-    ) +
+    labs(x = "CDI RP Threshold", y = "SEAS5 RP Threshold") +
     theme(
         panel.grid = element_blank(),
+        legend.position = "none",
+        plot.margin = margin(0, 0, 5, 5),
         axis.text.x = element_text(size = 7, angle = 45, hjust = 1),
         axis.text.y = element_text(size = 7)
+    )
+
+# Top marginal bar (CDI)
+p_top_zoom <- df_cdi_zoom |>
+    ggplot(aes(x = factor(rp), y = f1)) +
+    geom_col(fill = hdx_hex("sapphire-hdx"), width = 0.7) +
+    geom_text(aes(label = round(f1, 2)), vjust = -0.3, size = 2) +
+    scale_y_continuous(limits = c(0, max(df_cdi_zoom$f1) * 1.15), expand = c(0, 0)) +
+    labs(x = NULL, y = NULL, title = "CDI alone") +
+    theme(
+        axis.text.x = element_blank(),
+        axis.ticks.x = element_blank(),
+        axis.text.y = element_blank(),
+        axis.ticks.y = element_blank(),
+        axis.line = element_blank(),
+        panel.grid = element_blank(),
+        plot.margin = margin(0, 0, -10, 0)
+    )
+
+# Right marginal bar (SEAS5)
+p_right_zoom <- df_seas5_zoom |>
+    ggplot(aes(x = f1, y = factor(rp))) +
+    geom_col(fill = hdx_hex("tomato-hdx"), width = 0.7) +
+    geom_text(aes(label = round(f1, 2)), hjust = -0.2, size = 2) +
+    scale_x_continuous(limits = c(0, max(df_seas5_zoom$f1) * 1.15), expand = c(0, 0)) +
+    labs(x = NULL, y = NULL, title = "SEAS5 alone") +
+    theme(
+        axis.text.x = element_blank(),
+        axis.ticks.x = element_blank(),
+        axis.text.y = element_blank(),
+        axis.ticks.y = element_blank(),
+        axis.line = element_blank(),
+        panel.grid = element_blank(),
+        plot.margin = margin(0, 0, 0, -10)
+    )
+
+# Empty corner
+p_empty_zoom <- ggplot() + theme_void()
+
+# Combine with patchwork
+(p_top_zoom + p_empty_zoom + p_heat_zoom + p_right_zoom) +
+    plot_layout(
+        widths = c(4, 1),
+        heights = c(1, 4)
+    ) +
+    plot_annotation(
+        title = "Zoomed: Combined Trigger F1 (RP 3–5 range)",
+        subtitle = glue("Black border = proposed threshold (CDI ≈ RP {tuned_rp}, SEAS5 RP 4)")
     )
 ```
 
 ::: {.callout-note}
 ## Interpretation
 
-F1 peaks around RP 3–4 for both signals, declining at stricter thresholds (fewer triggers, more missed CERF years) or looser thresholds (more false positives). Our F1-tuned CDI threshold (~RP 3.9) falls within this optimal range. Within the CERF period, CDI at RP 4 catches 6 of 7 CERF allocation years — the only miss is 2012 (cdi_rp = 1.4), which would require an impractically low threshold to capture.
+CERF alignment shows a **plateau** in the RP 3–5 range — lowering the threshold doesn't improve performance (the same years trigger within the CERF period), and raising it only marginally affects F1 until you start missing CERF years at RP ≥ 5. This means CERF performance alone doesn't determine the optimal threshold.
+
+The **early:false ratio** (see previous chapter) breaks the tie: within the CERF-optimal plateau, SEAS5 RP ≥ 4 maximizes early warning value (6/10 droughts get March warning) while minimizing false early alerts (4 over 42 years, ratio 1.5:1). Lowering to RP 3 adds false alerts without improving CERF alignment; raising to RP 5 loses recent droughts (2021, 2023) without removing false positives.
+
+**Bottom line**: RP ~4 sits in the sweet spot — optimal for CERF alignment AND best early:false ratio for anticipatory action.
 :::
 
 ## Year-by-Year Alignment

--- a/book_afg_analysis/14_cerf_allocation_alignment.qmd
+++ b/book_afg_analysis/14_cerf_allocation_alignment.qmd
@@ -31,7 +31,8 @@ box::use(
     glue[glue],
     tibble[tibble],
     janitor[clean_names],
-    lubridate[year, as_date]
+    lubridate[year, as_date],
+    .. / R / utils[rp_empirical]
 )
 
 library(tidymodels)
@@ -127,6 +128,18 @@ cdi_weights <- coefs_ridge |>
     ) |>
     arrange(desc(contribution_pct)) |>
     select(term, estimate, weight, contribution_pct)
+
+# F1-optimized probability threshold → CDI threshold (same derivation as ch12)
+prob_drought <- predict(final_ridge_fit, df_apr, type = "prob")$.pred_yes
+
+thresholds <- seq(0.1, 0.9, by = 0.05)
+best_prob_threshold <- map_dfr(thresholds, function(thresh) {
+    pred <- factor(if_else(prob_drought > thresh, "yes", "no"), levels = c("yes", "no"))
+    tibble(threshold = thresh, f1 = yardstick::f_meas_vec(df_apr$drought, pred))
+}) |>
+    filter(f1 == max(f1, na.rm = TRUE)) |>
+    slice(1) |>
+    pull(threshold)
 ```
 
 ```{r}
@@ -161,22 +174,20 @@ calc_cdi <- function(data, weights_df) {
     cdi
 }
 
-rp_empirical <- function(x) {
-    r <- rank(-x, ties.method = "average")
-    q <- r / (length(x) + 1)
-    1 / q
-}
-
 df_historical <- tibble(
     year = df_apr$pub_year,
     drought_actual = df_apr$drought,
     cdi = calc_cdi(df_apr, cdi_weights),
+    prob_drought = prob_drought,
     seas5_mam = df_mar$`seas5 Mar-Apr-May`
 ) |>
     mutate(
-        cdi_rp = rp_empirical(cdi),
-        seas5_rp = rp_empirical(seas5_mam)
+        cdi_rp = rp_empirical(cdi, direction = "-1"),
+        seas5_rp = rp_empirical(seas5_mam, direction = "-1")
     )
+
+# CDI threshold from F1-optimized probability (consistent with ch12)
+cdi_threshold <- min(df_historical$cdi[df_historical$prob_drought > best_prob_threshold])
 
 # Join with CERF data — restrict to CERF coverage period (2006–2024)
 df_cerf_analysis <- df_historical |>
@@ -356,17 +367,17 @@ df_f1_by_rp |>
 
 df_cerf_analysis |>
     mutate(
-        cdi_rp4 = if_else(cdi_rp >= 4, "yes", "no"),
+        cdi_trig = if_else(cdi >= cdi_threshold, "yes", "no"),
         seas5_rp4 = if_else(seas5_rp >= 4, "yes", "no"),
-        combined = if_else(cdi_rp >= 4 | seas5_rp >= 4, "yes", "no")
+        combined = if_else(cdi >= cdi_threshold | seas5_rp >= 4, "yes", "no")
     ) |>
-    select(year, cerf, drought_actual, cdi_rp4, seas5_rp4, combined) |>
+    select(year, cerf, drought_actual, cdi_trig, seas5_rp4, combined) |>
     arrange(desc(year)) |>
     rename(
         Year = year,
         CERF = cerf,
         `ASI Drought` = drought_actual,
-        `CDI RP4` = cdi_rp4,
+        CDI = cdi_trig,
         `SEAS5 RP4` = seas5_rp4,
         `Combined` = combined
     ) |>
@@ -385,7 +396,7 @@ df_cerf_analysis |>
     ) |>
     tab_style(
         style = cell_fill(color = "steelblue", alpha = 0.4),
-        locations = cells_body(columns = `CDI RP4`, rows = `CDI RP4` == "yes")
+        locations = cells_body(columns = CDI, rows = CDI == "yes")
     ) |>
     tab_style(
         style = cell_fill(color = "steelblue", alpha = 0.4),
@@ -395,7 +406,7 @@ df_cerf_analysis |>
         style = cell_fill(color = "steelblue", alpha = 0.4),
         locations = cells_body(columns = Combined, rows = Combined == "yes")
     ) |>
-    tab_spanner(label = "Trigger (RP4)", columns = c(`CDI RP4`, `SEAS5 RP4`, `Combined`)) |>
+    tab_spanner(label = "Trigger", columns = c(CDI, `SEAS5 RP4`, `Combined`)) |>
     tab_footnote(
         footnote = "Red = CERF allocation | Gold = ASI drought | Blue = trigger fires",
         locations = cells_column_spanners()

--- a/book_afg_analysis/14_cerf_allocation_alignment.qmd
+++ b/book_afg_analysis/14_cerf_allocation_alignment.qmd
@@ -767,160 +767,143 @@ The trigger system is validated at multiple levels:
 This provides reasonable confidence that the trigger captures "real" droughts worth acting on. However, direct validation against food security outcomes remains a gap that could strengthen the evidence base for future iterations.
 :::
 
-## Appendix: RP Threshold Sensitivity
+## Appendix: ASI Threshold Sensitivity
 
-A key modeling choice is defining "drought" as ASI RP ≥ 4. This appendix tests whether RP 3 or RP 5 would produce better CERF alignment.
+A key modeling choice is defining "drought" as ASI RP ≥ 4. This appendix tests how well ASI itself (without the CDI model) aligns with CERF allocations at different RP thresholds.
+
+::: {.callout-note}
+## Methodology Note
+
+**ASI return periods** are calculated using the full 42-year record (1984–2025). Each year is ranked by ASI z-score and assigned an empirical return period based on its position in the historical distribution.
+
+**CERF alignment** is evaluated only on the ~20-year period where CERF Rapid Response data exists (2006–2025). The "Years ≥ RP" column counts how many years *within this evaluation window* exceed the given threshold — not the total count across all 42 years.
+
+This explains why RP 3 and RP 4 may show identical counts: years that fall between these thresholds in the full record happen to be outside the 2006–2025 CERF evaluation period.
+:::
 
 ```{r}
 #| label: rp-sensitivity-setup
 
-# Function to fit model and evaluate CERF alignment for a given RP threshold
-fit_and_evaluate <- function(rp_threshold, df_apr_raw, df_cerf_yr) {
+# Get ASI values for each year (from the outcome variable we already have)
+df_asi <- df_apr_raw |>
+    filter(!is.na(outcome_asi_zscore)) |>
+    select(pub_year, outcome_asi_zscore) |>
+    arrange(desc(outcome_asi_zscore)) |>
+    mutate(
+        rank = row_number(),
+        asi_rp = rp_empirical(outcome_asi_zscore, direction = "-1")
+    )
 
-    # Prepare data with this RP threshold
-    df <- df_apr_raw |>
-        filter(!is.na(outcome_asi_zscore)) |>
-        arrange(desc(outcome_asi_zscore)) |>
-        mutate(
-            rank = row_number(),
-            q_rank = rank / (n() + 1),
-            rp_emp = 1 / q_rank,
-            drought = factor(
-                if_else(rp_emp >= rp_threshold, "yes", "no"),
-                levels = c("yes", "no")
-            )
-        )
+# Join with CERF data (limited to 2005-2024)
+df_asi_cerf <- df_asi |>
+    inner_join(df_cerf_yr, by = c("pub_year" = "yr"))
 
-    n_drought_years <- sum(df$drought == "yes")
-
-    # Fit ridge model
-    df_model <- df |>
-        select(-outcome_asi_zscore, -rank, -q_rank, -rp_emp,
-               -starts_with("adm0_name"), -pub_date, -timestep)
-
-    recipe_spec <- recipe(drought ~ ., data = df_model) |>
-        step_rm(all_of(c("pub_year", APRIL_EXCLUDE_VARS, "precip_cumsum"))) |>
-        step_zv(all_predictors())
-
-    ridge_spec <- logistic_reg(penalty = tune(), mixture = 0) |>
-        set_engine("glmnet") |>
-        set_mode("classification")
-
-    wf <- workflow() |>
-        add_recipe(recipe_spec) |>
-        add_model(ridge_spec)
-
-    set.seed(SEED)
-    boots <- bootstraps(df_model, times = 15, strata = drought)
-    grid <- grid_regular(penalty(range = c(-4, 0)), levels = 20)
-
-    tune_res <- tune_grid(wf, resamples = boots, grid = grid,
-                          metrics = metric_set(f_meas),
-                          control = control_grid(save_pred = FALSE, verbose = FALSE))
-
-    best_pen <- select_best(tune_res, metric = "f_meas")
-    final_fit <- fit(finalize_workflow(wf, best_pen), data = df_model)
-
-    # Get CDI weights and threshold
-    coefs <- final_fit |>
-        extract_fit_parsnip() |>
-        tidy() |>
-        filter(term != "(Intercept)")
-
-    weights <- coefs |>
-        mutate(weight = -estimate / sum(abs(estimate)))
-
-    # Calculate CDI
-    calc_cdi_local <- function(data, weights_df) {
-        cdi <- rep(0, nrow(data))
-        for (i in seq_len(nrow(weights_df))) {
-            feat <- weights_df$term[i]
-            w <- weights_df$weight[i]
-            if (feat %in% colnames(data)) {
-                cdi <- cdi + w * data[[feat]]
-            }
-        }
-        cdi
-    }
-
-    cdi_vals <- calc_cdi_local(df_model, weights)
-    prob_drought <- predict(final_fit, df_model, type = "prob")$.pred_yes
-
-    # F1-optimized threshold
-    thresholds <- seq(0.1, 0.9, by = 0.05)
-    best_thresh <- map_dfr(thresholds, function(t) {
-        pred <- factor(if_else(prob_drought > t, "yes", "no"), levels = c("yes", "no"))
-        tibble(threshold = t, f1 = yardstick::f_meas_vec(df_model$drought, pred))
-    }) |>
-        filter(f1 == max(f1, na.rm = TRUE)) |>
-        slice(1) |>
-        pull(threshold)
-
-    cdi_threshold <- min(cdi_vals[prob_drought > best_thresh])
-
-    # Build historical for CERF analysis
-    df_hist <- tibble(
-        year = df$pub_year,
-        cdi = cdi_vals
-    ) |>
-        mutate(cdi_rp = rp_empirical(cdi, direction = "-1"))
-
-    # Join with CERF
-    df_cerf_eval <- df_hist |>
-        inner_join(df_cerf_yr, by = c("year" = "yr"))
-
-    # Evaluate CERF alignment
-    cdi_flag <- factor(
-        if_else(df_cerf_eval$cdi >= cdi_threshold, "yes", "no"),
+# Evaluate ASI vs CERF at different RP thresholds
+df_rp_sensitivity <- map_dfr(2:8, function(rp) {
+    asi_flag <- factor(
+        if_else(df_asi_cerf$asi_rp >= rp, "yes", "no"),
         levels = c("yes", "no")
     )
 
-    cerf_f1 <- yardstick::f_meas_vec(df_cerf_eval$cerf, cdi_flag)
-    cerf_auc <- yardstick::roc_auc_vec(df_cerf_eval$cerf, df_cerf_eval$cdi)
-    cerf_precision <- yardstick::precision_vec(df_cerf_eval$cerf, cdi_flag)
-    cerf_recall <- yardstick::recall_vec(df_cerf_eval$cerf, cdi_flag)
+    # Handle edge case where all predictions are same class
+    if (length(unique(asi_flag)) == 1) {
+        return(tibble(
+            rp_threshold = rp,
+            n_drought_years = sum(asi_flag == "yes"),
+            cerf_f1 = NA_real_,
+            cerf_precision = NA_real_,
+            cerf_recall = NA_real_,
+            trigger_years = list(df_asi_cerf$pub_year[asi_flag == "yes"])
+        ))
+    }
 
-    # Years that trigger
-    trigger_years <- df_cerf_eval$year[df_cerf_eval$cdi >= cdi_threshold]
+    cerf_f1 <- yardstick::f_meas_vec(df_asi_cerf$cerf, asi_flag)
+    cerf_precision <- yardstick::precision_vec(df_asi_cerf$cerf, asi_flag)
+    cerf_recall <- yardstick::recall_vec(df_asi_cerf$cerf, asi_flag)
 
     tibble(
-        rp_threshold = rp_threshold,
-        n_drought_years = n_drought_years,
-        cerf_auc = cerf_auc,
+        rp_threshold = rp,
+        n_drought_years = sum(asi_flag == "yes"),
         cerf_f1 = cerf_f1,
         cerf_precision = cerf_precision,
         cerf_recall = cerf_recall,
-        trigger_years = list(trigger_years)
+        trigger_years = list(df_asi_cerf$pub_year[asi_flag == "yes"])
     )
-}
-
-# Run for RP 3, 4, 5
-df_rp_sensitivity <- map_dfr(c(3, 4, 5), function(rp) {
-    fit_and_evaluate(rp, df_apr_raw, df_cerf_yr)
 })
+
+# Also calculate AUC (threshold-free) using continuous ASI
+asi_auc <- yardstick::roc_auc_vec(df_asi_cerf$cerf, df_asi_cerf$outcome_asi_zscore)
 ```
 
-### CERF Alignment by Training RP
+### How well does ASI predict CERF allocations?
+
+The plot below shows F1, precision, and recall for ASI at different RP thresholds against CERF Rapid Response allocations.
+
+```{r}
+#| label: fig-asi-cerf-alignment
+#| fig-cap: "ASI vs CERF Alignment by RP Threshold"
+#| fig-height: 4.5
+#| fig-width: 8
+
+p_asi_cerf <- df_rp_sensitivity |>
+    select(rp_threshold, cerf_f1, cerf_precision, cerf_recall) |>
+    pivot_longer(cols = c(cerf_f1, cerf_precision, cerf_recall),
+                 names_to = "metric", values_to = "value") |>
+    mutate(metric = case_when(
+        metric == "cerf_f1" ~ "F1",
+        metric == "cerf_precision" ~ "Precision",
+        metric == "cerf_recall" ~ "Recall"
+    )) |>
+    ggplot(aes(x = rp_threshold, y = value, color = metric)) +
+    geom_line(linewidth = 1) +
+    geom_point(size = 3) +
+    geom_vline(xintercept = 4, linetype = "dashed", alpha = 0.5) +
+    annotate("text", x = 4.15, y = 0.95, label = "RP 4\n(current)", hjust = 0, size = 3) +
+    scale_x_continuous(breaks = 2:8) +
+    scale_y_continuous(limits = c(0, 1)) +
+    scale_color_manual(values = c(
+        "F1" = hdx_hex("tomato-hdx"),
+        "Precision" = hdx_hex("sapphire-hdx"),
+        "Recall" = hdx_hex("mint-hdx")
+    )) +
+    labs(
+        title = "ASI vs CERF Alignment by RP Threshold",
+        subtitle = glue("How well does ASI RP ≥ X predict CERF Rapid Response allocations? (AUC = {round(asi_auc, 2)})"),
+        x = "ASI RP Threshold",
+        y = "Score",
+        color = "Metric"
+    ) +
+    theme_minimal() +
+    theme(legend.position = "bottom")
+
+ggsave("outputs/figures/fig-asi-cerf-alignment.png", p_asi_cerf, width = 8, height = 4.5, dpi = 300)
+
+# Paper version with larger text
+p_asi_cerf_paper <- p_asi_cerf + theme_minimal(base_size = 14) + theme(legend.position = "bottom")
+ggsave("outputs/figures/paper/fig-asi-cerf-alignment.png", p_asi_cerf_paper, width = 8, height = 4.5, dpi = 300)
+
+p_asi_cerf
+```
 
 ```{r}
 #| label: rp-sensitivity-table
 
 df_rp_sensitivity |>
-    select(rp_threshold, n_drought_years, cerf_auc, cerf_f1, cerf_precision, cerf_recall) |>
+    select(rp_threshold, n_drought_years, cerf_f1, cerf_precision, cerf_recall) |>
     gt() |>
     tab_header(
-        title = "CERF Alignment by ASI RP Training Threshold",
-        subtitle = "How does the choice of 'drought' definition affect CERF prediction?"
+        title = "ASI-CERF Alignment by RP Threshold",
+        subtitle = glue("Evaluating ASI RP ≥ X as predictor of CERF allocations (n = {nrow(df_asi_cerf)} years)")
     ) |>
     cols_label(
-        rp_threshold = "Training RP",
-        n_drought_years = "Drought Years",
-        cerf_auc = "AUC",
+        rp_threshold = "RP Threshold",
+        n_drought_years = "Years ≥ RP",
         cerf_f1 = "F1",
         cerf_precision = "Precision",
         cerf_recall = "Recall"
     ) |>
-    fmt_number(columns = c(cerf_auc, cerf_f1, cerf_precision, cerf_recall), decimals = 3) |>
+    fmt_number(columns = c(cerf_f1, cerf_precision, cerf_recall), decimals = 3) |>
+    sub_missing(missing_text = "—") |>
     tab_style(
         style = cell_fill(color = "lightgreen"),
         locations = cells_body(rows = rp_threshold == 4)
@@ -928,62 +911,63 @@ df_rp_sensitivity |>
     tab_footnote(
         footnote = "Green = current choice (RP ≥ 4)",
         locations = cells_column_labels(columns = rp_threshold)
+    ) |>
+    tab_footnote(
+        footnote = "Count within CERF evaluation period (2006–2025) only; ASI RPs based on full 42-year climatology",
+        locations = cells_column_labels(columns = n_drought_years)
     )
 ```
 
-### Which Years Trigger Under Each Threshold?
+### Which ASI years align with CERF?
 
 ```{r}
-#| label: rp-sensitivity-years
+#| label: tbl-asi-cerf-years
+#| tbl-cap: "ASI Drought Years vs CERF Allocations"
 
-# Extract trigger years for comparison
-trigger_rp3 <- df_rp_sensitivity |> filter(rp_threshold == 3) |> pull(trigger_years) |> unlist()
-trigger_rp4 <- df_rp_sensitivity |> filter(rp_threshold == 4) |> pull(trigger_years) |> unlist()
-trigger_rp5 <- df_rp_sensitivity |> filter(rp_threshold == 5) |> pull(trigger_years) |> unlist()
+# Show ASI drought years vs CERF years
+cerf_years <- df_cerf_yr |> filter(cerf == "yes") |> pull(yr)
 
-# Build comparison table
-all_years <- sort(unique(c(trigger_rp3, trigger_rp4, trigger_rp5)))
-
-tibble(
-    year = all_years,
-    rp3 = if_else(all_years %in% trigger_rp3, "✓", ""),
-    rp4 = if_else(all_years %in% trigger_rp4, "✓", ""),
-    rp5 = if_else(all_years %in% trigger_rp5, "✓", ""),
-    cerf = if_else(all_years %in% (df_cerf_yr |> filter(cerf == "yes") |> pull(yr)), "✓", "")
-) |>
-    arrange(desc(year)) |>
+df_asi_cerf |>
+    mutate(
+        asi_rp3 = if_else(asi_rp >= 3, "✓", ""),
+        asi_rp4 = if_else(asi_rp >= 4, "✓", ""),
+        asi_rp5 = if_else(asi_rp >= 5, "✓", ""),
+        cerf = if_else(pub_year %in% cerf_years, "✓", "")
+    ) |>
+    select(pub_year, asi_rp3, asi_rp4, asi_rp5, cerf) |>
+    arrange(desc(pub_year)) |>
     gt() |>
     tab_header(
-        title = "Trigger Years by Training RP Threshold",
-        subtitle = "Which years fire under each definition of 'drought'?"
+        title = "ASI Drought Years vs CERF Allocations",
+        subtitle = "Does ASI RP ≥ X capture CERF years?"
     ) |>
     cols_label(
-        year = "Year",
-        rp3 = "RP ≥ 3",
-        rp4 = "RP ≥ 4",
-        rp5 = "RP ≥ 5",
+        pub_year = "Year",
+        asi_rp3 = "RP ≥ 3",
+        asi_rp4 = "RP ≥ 4",
+        asi_rp5 = "RP ≥ 5",
         cerf = "CERF"
     ) |>
     tab_style(
         style = cell_fill(color = "tomato", alpha = 0.3),
         locations = cells_body(columns = cerf, rows = cerf == "✓")
     ) |>
-    tab_spanner(label = "Training Threshold", columns = c(rp3, rp4, rp5))
+    tab_style(
+        style = cell_fill(color = "lightgreen", alpha = 0.3),
+        locations = cells_body(columns = asi_rp4)
+    ) |>
+    tab_spanner(label = "ASI Threshold", columns = c(asi_rp3, asi_rp4, asi_rp5))
 ```
 
 ::: {.callout-note}
-## RP Sensitivity Findings
+## ASI Threshold Findings
 
-The choice of RP threshold for defining "drought" affects:
+**Key observations:**
 
-1. **Number of positive training examples**: RP 3 includes more years (~14), RP 5 fewer (~8)
-2. **CERF alignment**: All three thresholds produce similar AUC/F1, suggesting the CDI learns robust drought signals regardless of exact threshold
-3. **Trigger years**: The core drought years (major CERF allocations) are captured at all thresholds; differences occur at the margins
-
-**Why RP 4?**
-
-- Provides balanced class sizes for training (10/42 years)
-- Aligns with typical AA activation frequencies (every 3-5 years)
-- Performance is robust: nearby thresholds (RP 3, RP 5) yield similar CERF alignment
-- The "plateau" in CERF F1 across RP 3-5 indicates we're in a stable operating region
+1. **ASI-CERF relationship**: ASI achieves AUC = `r round(asi_auc, 2)` against CERF allocations, indicating the outcome variable does capture droughts that warranted humanitarian response
+2. **Threshold sensitivity**: The plot shows how precision/recall trade off as the RP threshold increases
+3. **RP 4 rationale**:
+   - Captures ~`r sum(df_asi_cerf$asi_rp >= 4)` years out of `r nrow(df_asi_cerf)` (~`r round(100*sum(df_asi_cerf$asi_rp >= 4)/nrow(df_asi_cerf))`%)
+   - Represents "worse than 1-in-4 years" — severe enough to warrant early action
+   - Aligns with typical AA activation frequencies (every 3-5 years)
 :::

--- a/book_afg_analysis/15_baseline_sensitivity.qmd
+++ b/book_afg_analysis/15_baseline_sensitivity.qmd
@@ -1,0 +1,1849 @@
+---
+title: "Sensitivity Analysis: SEAS5 Climatology Baseline"
+format:
+  html:
+    toc: true
+    toc-depth: 3
+    code-fold: true
+execute:
+  warning: false
+  message: false
+project:
+  execute-dir: project
+---
+
+## Introduction
+
+ECMWF uses 1993-2016 as their climatology reference period for SEAS5, citing pre-1990 satellite and observation network quality issues. This raises the question: **does our SEAS5 early warning component perform differently when we exclude potentially unreliable pre-1991 forecasts from the baseline?**
+
+This analysis keeps the CDI unchanged (1984-2025 baseline) and tests only the SEAS5 early warning component under two baseline periods:
+
+| Component | Baseline | Rationale |
+|-----------|----------|-----------|
+| CDI (April trigger) | 1984-2025 | ASI/ERA5 observations are reliable; maximize sample |
+| SEAS5 (March early warning) | Compare 1984-2025 vs 1991-2025 | Test sensitivity to pre-1991 forecast quality |
+
+```{r}
+#| label: setup
+
+box::use(
+    dplyr[...],
+    tidyr[...],
+    ggplot2[...],
+    gghdx[...],
+    cumulus[...],
+    purrr[...],
+    glue[glue],
+    tibble[tibble],
+    lubridate[...],
+    janitor[clean_names],
+    stringr[str_detect],
+    .. / R / utils[rp_empirical]
+)
+
+library(tidymodels)
+library(gt)
+library(patchwork)
+gghdx()
+```
+
+```{r}
+#| label: config
+
+# Return period threshold for defining drought
+RP_THRESHOLD <- 4
+
+# Bootstrap resamples for cross-validation
+N_BOOTSTRAP <- 30
+
+# Random seed
+SEED <- 42
+
+# Provinces of interest
+PROVINCES_AOI <- c("Faryab", "Sar-e-Pul", "Jawzjan", "Balkh", "Badghis")
+
+# Feature set paths (uses existing 1984 baseline)
+FEATURE_PATHS <- list(
+    march = "ds-aa-afg-drought/processed/vector/2026_mar_pub_feature_set_v1.parquet",
+    april = "ds-aa-afg-drought/processed/vector/2026_april_pub_feature_set_v1.parquet"
+)
+
+# Variables to exclude from CDI model
+APRIL_EXCLUDE_VARS <- c("total_precipitation_sum", "seas5 Apr", "seas5 May")
+
+# SEAS5 baseline periods to compare
+SEAS5_BASELINES <- list(
+    "1984-2025" = 1984,
+    "1991-2025" = 1991
+)
+```
+
+## Load Data & Fit CDI Model
+
+We use the existing feature sets (1984-2025 baseline) for CDI construction, identical to the main analysis.
+
+```{r}
+#| label: load-data
+
+# Load feature sets
+df_mar_raw <- blob_read(name = FEATURE_PATHS$march, container = "projects")
+df_apr_raw <- blob_read(name = FEATURE_PATHS$april, container = "projects")
+
+# Prepare modeling data with empirical RP thresholding
+prepare_model_data <- function(df, rp_threshold = RP_THRESHOLD) {
+    df |>
+        filter(!is.na(outcome_asi_zscore)) |>
+        arrange(desc(outcome_asi_zscore)) |>
+        mutate(
+            rank = row_number(),
+            q_rank = rank / (n() + 1),
+            rp_emp = 1 / q_rank,
+            drought = factor(
+                if_else(rp_emp >= rp_threshold, "yes", "no"),
+                levels = c("yes", "no")
+            )
+        ) |>
+        select(-outcome_asi_zscore, -rank, -q_rank, -rp_emp,
+               -starts_with("adm0_name"), -pub_date, -timestep)
+}
+
+df_mar <- prepare_model_data(df_mar_raw)
+df_apr <- prepare_model_data(df_apr_raw)
+```
+
+```{r}
+#| label: fit-cdi-model
+
+# Fit ridge model (identical to main analysis)
+ridge_spec <- logistic_reg(penalty = tune(), mixture = 0) |>
+    set_engine("glmnet") |>
+    set_mode("classification")
+
+ridge_recipe <- recipe(drought ~ ., data = df_apr) |>
+    step_rm(all_of(c("pub_year", APRIL_EXCLUDE_VARS, "precip_cumsum"))) |>
+    step_zv(all_predictors())
+
+ridge_wf <- workflow() |>
+    add_recipe(ridge_recipe) |>
+    add_model(ridge_spec)
+
+set.seed(SEED)
+ridge_boots <- bootstraps(df_apr, times = N_BOOTSTRAP, strata = drought)
+penalty_grid <- grid_regular(penalty(range = c(-4, 0)), levels = 30)
+
+ridge_tune <- tune_grid(
+    ridge_wf,
+    resamples = ridge_boots,
+    grid = penalty_grid,
+    metrics = metric_set(roc_auc, f_meas),
+    control = control_grid(save_pred = TRUE)
+)
+
+best_penalty <- select_best(ridge_tune, metric = "f_meas")
+final_ridge_fit <- fit(finalize_workflow(ridge_wf, best_penalty), data = df_apr)
+
+# Extract CDI weights
+coefs_ridge <- final_ridge_fit |>
+    extract_fit_parsnip() |>
+    tidy() |>
+    filter(term != "(Intercept)")
+
+cdi_weights <- coefs_ridge |>
+    mutate(
+        weight = -estimate / sum(abs(estimate)),
+        contribution_pct = abs(weight) * 100
+    ) |>
+    arrange(desc(contribution_pct)) |>
+    select(term, estimate, weight, contribution_pct)
+
+# CDI calculation helper
+calc_cdi <- function(data, weights_df) {
+    cdi <- rep(0, nrow(data))
+    for (i in seq_len(nrow(weights_df))) {
+        feat <- weights_df$term[i]
+        w <- weights_df$weight[i]
+        if (feat %in% colnames(data)) {
+            cdi <- cdi + w * data[[feat]]
+        }
+    }
+    cdi
+}
+
+# Get F1-optimized threshold
+prob_drought <- predict(final_ridge_fit, df_apr, type = "prob")$.pred_yes
+
+thresholds <- seq(0.1, 0.9, by = 0.05)
+best_prob_threshold <- map_dfr(thresholds, function(thresh) {
+    pred <- factor(if_else(prob_drought > thresh, "yes", "no"), levels = c("yes", "no"))
+    tibble(threshold = thresh, f1 = yardstick::f_meas_vec(df_apr$drought, pred))
+}) |>
+    filter(f1 == max(f1, na.rm = TRUE)) |>
+    slice(1) |>
+    pull(threshold)
+
+# Build CDI record
+df_cdi <- tibble(
+    year = df_apr$pub_year,
+    drought_actual = df_apr$drought,
+    cdi = calc_cdi(df_apr, cdi_weights),
+    prob_drought = prob_drought
+) |>
+    mutate(cdi_rp = rp_empirical(cdi, direction = "-1"))
+
+cdi_threshold <- min(df_cdi$cdi[df_cdi$prob_drought > best_prob_threshold])
+cdi_fires <- df_cdi$cdi >= cdi_threshold
+```
+
+## SEAS5 Baseline Comparison
+
+Now we load raw SEAS5 data and calculate z-scores under both baseline periods.
+
+```{r}
+#| label: load-seas5-raw
+
+# Load raw SEAS5 data
+df_seas5_raw <- cumulus::pg_load_seas5_historical(
+    iso3 = "AFG",
+    adm_name = PROVINCES_AOI,
+    adm_level = 1,
+    convert_units = TRUE
+)
+
+# Get area weights for province aggregation
+df_area <- blob_read(
+    name = "ds-aa-afg-drought/raw/vector/historical_era5_land_ndjfmam_lte2025.parquet",
+    stage = "dev",
+    container_name = "projects"
+) |>
+    clean_names() |>
+    filter(adm1_name %in% PROVINCES_AOI) |>
+    distinct(adm1_name, shape_area)
+
+# Aggregate SEAS5 MAM forecast and merge provinces
+df_seas5_mam <- cumulus::seas5_aggregate_forecast(
+    df = df_seas5_raw,
+    value = "mean",
+    valid_months = c(3, 4, 5),
+    by = c("iso3", "pcode", "name", "issued_date")
+) |>
+    filter(month(issued_date) == 3) |>
+    rename(adm1_name = name, value = mean) |>
+    left_join(df_area, by = "adm1_name") |>
+    group_by(issued_date) |>
+    summarise(
+        value = weighted.mean(value, w = shape_area, na.rm = TRUE),
+        .groups = "drop"
+    ) |>
+    mutate(year = year(issued_date))
+```
+
+```{r}
+#| label: calc-seas5-zscores
+
+# Calculate z-scores under both baselines for comparison
+# For 1984 baseline: use 1984-2025 mean/SD
+# For 1991 baseline: use 1991-2025 mean/SD
+
+# 1984 baseline statistics
+mean_1984 <- mean(df_seas5_mam$value[df_seas5_mam$year >= 1984], na.rm = TRUE)
+sd_1984 <- sd(df_seas5_mam$value[df_seas5_mam$year >= 1984], na.rm = TRUE)
+
+# 1991 baseline statistics
+mean_1991 <- mean(df_seas5_mam$value[df_seas5_mam$year >= 1991], na.rm = TRUE)
+sd_1991 <- sd(df_seas5_mam$value[df_seas5_mam$year >= 1991], na.rm = TRUE)
+
+# Create comparison dataframe with both z-scores
+df_seas5_compare <- df_seas5_mam |>
+    filter(year >= 1984, year <= 2025) |>
+    mutate(
+        # Z-scores under each baseline (inverted so positive = drought)
+        zscore_1984 = -((value - mean_1984) / sd_1984),
+        zscore_1991 = -((value - mean_1991) / sd_1991)
+    )
+
+# Add empirical RPs
+# For 1984 baseline: RP calculated on all 1984-2025 years
+df_seas5_compare <- df_seas5_compare |>
+    mutate(seas5_rp_1984 = rp_empirical(zscore_1984, direction = "-1"))
+
+# For 1991 baseline: RP calculated only on 1991+ years
+df_1991_rp <- df_seas5_compare |>
+    filter(year >= 1991) |>
+    mutate(seas5_rp_1991 = rp_empirical(zscore_1991, direction = "-1")) |>
+    select(year, seas5_rp_1991)
+
+df_seas5_compare <- df_seas5_compare |>
+    left_join(df_1991_rp, by = "year")
+```
+
+### Z-Score Distribution Comparison
+
+```{r}
+#| label: zscore-distribution
+#| fig-height: 5
+#| fig-width: 10
+
+# Prepare data for density plot (long format)
+df_zscore_long <- df_seas5_compare |>
+    filter(year >= 1991) |>  # Only years where both baselines valid
+    select(year, zscore_1984, zscore_1991) |>
+    pivot_longer(
+        cols = c(zscore_1984, zscore_1991),
+        names_to = "baseline",
+        values_to = "zscore"
+    ) |>
+    mutate(baseline = if_else(baseline == "zscore_1984", "1984-2025", "1991-2025"))
+
+p1 <- df_zscore_long |>
+    ggplot(aes(x = zscore, fill = baseline)) +
+    geom_density(alpha = 0.5) +
+    scale_fill_manual(values = c("1984-2025" = hdx_hex("sapphire-hdx"),
+                                  "1991-2025" = hdx_hex("tomato-hdx"))) +
+    labs(
+        title = "SEAS5 MAM Z-Score Distribution",
+        subtitle = "Comparing baseline periods (1991-2025 years only)",
+        x = "Z-score (positive = drought)",
+        y = "Density",
+        fill = "Baseline"
+    )
+
+p2 <- df_seas5_compare |>
+    filter(year >= 1991) |>
+    ggplot(aes(x = zscore_1984, y = zscore_1991)) +
+    geom_abline(slope = 1, intercept = 0, linetype = "dashed", color = "grey50") +
+    geom_point(size = 2.5, color = hdx_hex("sapphire-hdx")) +
+    geom_smooth(method = "lm", se = FALSE, color = hdx_hex("mint-hdx")) +
+    labs(
+        title = "Z-Score Comparison: 1984 vs 1991 Baseline",
+        subtitle = "Points above diagonal = higher z-score under 1991 baseline",
+        x = "Z-score (1984-2025 baseline)",
+        y = "Z-score (1991-2025 baseline)"
+    )
+
+p1 + p2
+```
+
+```{r}
+#| label: zscore-correlation
+
+# Correlation between z-scores (on overlapping years only)
+cor_zscores <- cor(
+    df_seas5_compare$zscore_1984[df_seas5_compare$year >= 1991],
+    df_seas5_compare$zscore_1991[df_seas5_compare$year >= 1991],
+    use = "complete.obs"
+)
+
+# Mean/SD comparison for each baseline period
+baseline_stats <- tibble(
+    baseline = c("1984-2025", "1991-2025"),
+    n_years = c(
+        sum(df_seas5_mam$year >= 1984 & df_seas5_mam$year <= 2025),
+        sum(df_seas5_mam$year >= 1991 & df_seas5_mam$year <= 2025)
+    ),
+    mean_raw = c(
+        mean(df_seas5_mam$value[df_seas5_mam$year >= 1984], na.rm = TRUE),
+        mean(df_seas5_mam$value[df_seas5_mam$year >= 1991], na.rm = TRUE)
+    ),
+    sd_raw = c(
+        sd(df_seas5_mam$value[df_seas5_mam$year >= 1984], na.rm = TRUE),
+        sd(df_seas5_mam$value[df_seas5_mam$year >= 1991], na.rm = TRUE)
+    )
+)
+
+baseline_stats |>
+    knitr::kable(
+        col.names = c("Baseline", "N Years", "Mean (mm)", "SD (mm)"),
+        caption = "SEAS5 MAM climatology statistics by baseline period",
+        digits = 1
+    )
+```
+
+### What Do RP Thresholds Mean in mm?
+
+To make the thresholds tangible, we can back-calculate from z-scores to actual precipitation values. For each RP threshold, we find the corresponding z-score percentile, then convert to mm using the baseline's mean and SD.
+
+```{r}
+#| label: mm-thresholds
+#| fig-height: 5
+#| fig-width: 10
+
+# For each baseline, find the z-score threshold for each RP
+# RP = (n+1) / rank, so for RP=4 with n=35, rank = (35+1)/4 = 9
+# This means the 9th highest z-score (or ~75th percentile of drought severity)
+
+# Get z-scores for each baseline period
+zscores_1984 <- df_seas5_compare$zscore_1984[df_seas5_compare$year >= 1984]
+zscores_1991 <- df_seas5_compare$zscore_1991[df_seas5_compare$year >= 1991]
+
+# Function to find z-score threshold for a given RP
+get_zscore_threshold <- function(zscores, rp) {
+    n <- length(zscores)
+    rank <- (n + 1) / rp
+    # Sort descending (higher z = more severe drought)
+    sorted <- sort(zscores, decreasing = TRUE)
+    # Interpolate to get the threshold
+    if (rank <= 1) return(sorted[1])
+    if (rank >= n) return(sorted[n])
+    lower_idx <- floor(rank)
+    upper_idx <- ceiling(rank)
+    frac <- rank - lower_idx
+    sorted[lower_idx] * (1 - frac) + sorted[upper_idx] * frac
+}
+
+# Calculate thresholds for RPs 3-7 for both baselines
+rp_thresholds <- map_dfr(3:7, function(rp) {
+    z_1984 <- get_zscore_threshold(zscores_1984, rp)
+    z_1991 <- get_zscore_threshold(zscores_1991, rp)
+
+    # Convert z-score back to mm: value = mean - zscore * sd
+    # (since zscore = -(value - mean)/sd for drought)
+    mm_1984 <- mean_1984 - z_1984 * sd_1984
+    mm_1991 <- mean_1991 - z_1991 * sd_1991
+
+    tibble(
+        rp = rp,
+        z_1984 = z_1984,
+        z_1991 = z_1991,
+        mm_1984 = mm_1984,
+        mm_1991 = mm_1991
+    )
+})
+
+# Plot: mm thresholds by RP for each baseline
+p_mm <- rp_thresholds |>
+    select(rp, mm_1984, mm_1991) |>
+    pivot_longer(cols = c(mm_1984, mm_1991), names_to = "baseline", values_to = "mm") |>
+    mutate(baseline = if_else(baseline == "mm_1984", "1984-2025", "1991-2025")) |>
+    ggplot(aes(x = rp, y = mm, color = baseline, group = baseline)) +
+    geom_line(linewidth = 1.2) +
+    geom_point(size = 3) +
+    geom_hline(aes(yintercept = mean_1984), linetype = "dashed", color = hdx_hex("sapphire-hdx"), alpha = 0.5) +
+    geom_hline(aes(yintercept = mean_1991), linetype = "dashed", color = hdx_hex("tomato-hdx"), alpha = 0.5) +
+    annotate("text", x = 7.2, y = mean_1984, label = paste0("Mean (1984): ", round(mean_1984, 0), " mm"),
+             hjust = 0, size = 3, color = hdx_hex("sapphire-hdx")) +
+    annotate("text", x = 7.2, y = mean_1991, label = paste0("Mean (1991): ", round(mean_1991, 0), " mm"),
+             hjust = 0, size = 3, color = hdx_hex("tomato-hdx")) +
+    scale_color_manual(values = c("1984-2025" = hdx_hex("sapphire-hdx"),
+                                   "1991-2025" = hdx_hex("tomato-hdx"))) +
+    scale_x_continuous(breaks = 3:7, limits = c(3, 8.5)) +
+    labs(
+        title = "SEAS5 Precipitation Threshold by Return Period",
+        subtitle = "Lower precipitation = more severe drought signal",
+        x = "Return Period (years)",
+        y = "SEAS5 MAM Forecast (mm)",
+        color = "Baseline"
+    ) +
+    theme(legend.position = "bottom")
+
+p_mm
+```
+
+```{r}
+#| label: mm-threshold-table
+
+rp_thresholds |>
+    mutate(
+        across(starts_with("z_"), ~ round(.x, 2)),
+        across(starts_with("mm_"), ~ round(.x, 0)),
+        mm_diff = mm_1991 - mm_1984
+    ) |>
+    select(rp, z_1984, mm_1984, z_1991, mm_1991, mm_diff) |>
+    gt() |>
+    tab_header(
+        title = "SEAS5 Trigger Thresholds in mm",
+        subtitle = "Forecast precipitation below these values triggers early warning"
+    ) |>
+    tab_spanner(label = "1984-2025 Baseline", columns = c(z_1984, mm_1984)) |>
+    tab_spanner(label = "1991-2025 Baseline", columns = c(z_1991, mm_1991)) |>
+    cols_label(
+        rp = "RP",
+        z_1984 = "Z-score",
+        mm_1984 = "mm",
+        z_1991 = "Z-score",
+        mm_1991 = "mm",
+        mm_diff = "Δ mm"
+    ) |>
+    tab_style(
+        style = cell_fill(color = "#FFF3E0"),
+        locations = cells_body(rows = rp == 4)
+    ) |>
+    tab_style(
+        style = cell_fill(color = "#F3E5F5"),
+        locations = cells_body(rows = rp == 6)
+    ) |>
+    tab_footnote(
+        footnote = "Orange = RP4 threshold; Purple = RP6 threshold",
+        locations = cells_column_labels(columns = rp)
+    )
+```
+
+::: {.callout-note}
+## Interpreting the Thresholds
+
+```{r}
+#| label: threshold-interpretation
+#| results: asis
+
+mm_rp4_1991 <- round(rp_thresholds$mm_1991[rp_thresholds$rp == 4], 0)
+mm_rp6_1991 <- round(rp_thresholds$mm_1991[rp_thresholds$rp == 6], 0)
+mm_rp4_1984 <- round(rp_thresholds$mm_1984[rp_thresholds$rp == 4], 0)
+mm_rp6_1984 <- round(rp_thresholds$mm_1984[rp_thresholds$rp == 6], 0)
+
+cat(paste0("**Using 1991-2025 baseline:**\n\n"))
+cat(paste0("- RP ≥ 4 triggers when SEAS5 forecasts **< ", mm_rp4_1991, " mm** for MAM\n"))
+cat(paste0("- RP ≥ 6 triggers when SEAS5 forecasts **< ", mm_rp6_1991, " mm** for MAM\n\n"))
+
+cat(paste0("**Using 1984-2025 baseline:**\n\n"))
+cat(paste0("- RP ≥ 4 triggers when SEAS5 forecasts **< ", mm_rp4_1984, " mm** for MAM\n"))
+cat(paste0("- RP ≥ 6 triggers when SEAS5 forecasts **< ", mm_rp6_1984, " mm** for MAM\n\n"))
+
+cat("The 1991 baseline has a slightly different climatological mean, which shifts the mm thresholds accordingly.")
+```
+:::
+
+**Z-score correlation**: r = `r round(cor_zscores, 3)` — on the overlapping years (1991-2025), the two baselines produce highly correlated z-scores, but the 1991 baseline has a different mean/SD reference point.
+
+### Year-by-Year Comparison
+
+For a fair comparison, we evaluate both SEAS5 baselines on the **overlapping years** (1991-2025) where both can be assessed. This means:
+
+- **1984-2025 baseline**: z-scores calculated using 1984-2025 mean/SD, RP calculated on 1984-2025
+- **1991-2025 baseline**: z-scores calculated using 1991-2025 mean/SD, RP calculated on 1991-2025
+
+```{r}
+#| label: year-comparison-table
+
+# Combine with CDI and drought status
+df_comparison <- df_seas5_compare |>
+    left_join(
+        df_cdi |> select(year, drought_actual, cdi, cdi_rp),
+        by = "year"
+    ) |>
+    filter(!is.na(drought_actual)) |>
+    mutate(
+        cdi_fires = cdi >= cdi_threshold,
+        seas5_fires_1984 = seas5_rp_1984 >= 4,
+        seas5_fires_1991 = seas5_rp_1991 >= 4,
+        baseline_disagree = case_when(
+            is.na(seas5_rp_1991) ~ NA,
+            TRUE ~ seas5_fires_1984 != seas5_fires_1991
+        )
+    )
+
+# Show years where baselines disagree on SEAS5 trigger (only for 1991+ years)
+df_disagree <- df_comparison |>
+    filter(!is.na(baseline_disagree), baseline_disagree) |>
+    arrange(desc(year))
+
+if (nrow(df_disagree) > 0) {
+    df_disagree |>
+        select(year, drought_actual,
+               zscore_1984, seas5_rp_1984, seas5_fires_1984,
+               zscore_1991, seas5_rp_1991, seas5_fires_1991) |>
+        mutate(across(contains("zscore"), ~ round(.x, 2))) |>
+        mutate(across(contains("rp"), ~ round(.x, 1))) |>
+        gt() |>
+        tab_header(
+            title = "Years Where SEAS5 Baseline Choice Affects Trigger (RP >= 4)",
+            subtitle = "Different trigger decisions under 1984 vs 1991 baseline (1991-2025 only)"
+        ) |>
+        tab_spanner(label = "1984-2025 Baseline", columns = c(zscore_1984, seas5_rp_1984, seas5_fires_1984)) |>
+        tab_spanner(label = "1991-2025 Baseline", columns = c(zscore_1991, seas5_rp_1991, seas5_fires_1991)) |>
+        tab_style(
+            style = cell_fill(color = "tomato", alpha = 0.3),
+            locations = cells_body(columns = drought_actual, rows = drought_actual == "yes")
+        ) |>
+        cols_label(
+            year = "Year",
+            drought_actual = "Drought",
+            zscore_1984 = "Z-score",
+            seas5_rp_1984 = "RP",
+            seas5_fires_1984 = "Fires",
+            zscore_1991 = "Z-score",
+            seas5_rp_1991 = "RP",
+            seas5_fires_1991 = "Fires"
+        )
+} else {
+    cat("No years have different SEAS5 trigger decisions between baselines at RP >= 4.")
+}
+```
+
+## Early Warning Performance Comparison
+
+Following the analysis in the trigger proposal chapter, we evaluate SEAS5's value as an early warning signal under both baselines. The key metric is **early warnings per false positive added** — droughts that get one month earlier warning vs false alerts that SEAS5 adds beyond what CDI already triggers.
+
+First, we show the **operational evaluation** where each baseline is evaluated on its full record. This reflects what would actually happen if we used each baseline:
+
+- 1984-2025 baseline: evaluated on all 42 years (1984-2025)
+- 1991-2025 baseline: evaluated on 35 years (1991-2025)
+
+```{r}
+#| label: early-warning-analysis
+
+# Calculate early warning metrics for each baseline and RP threshold
+calc_ew_metrics <- function(df, seas5_rp_col, baseline_label) {
+    map_dfr(3:7, function(rp) {
+        seas5_fires <- df[[seas5_rp_col]] >= rp
+
+        droughts_early <- sum(seas5_fires & df$drought_actual == "yes", na.rm = TRUE)
+        fp_total <- sum(seas5_fires & df$drought_actual == "no", na.rm = TRUE)
+        # FP added = SEAS5 fires, CDI doesn't, not a drought
+        fp_added <- sum(seas5_fires & !df$cdi_fires & df$drought_actual == "no", na.rm = TRUE)
+        n_drought <- sum(df$drought_actual == "yes", na.rm = TRUE)
+
+        # Years where FP added
+        years_added <- df$year[seas5_fires & !df$cdi_fires & df$drought_actual == "no"]
+        years_added_str <- if (length(years_added) > 0) paste(sort(years_added), collapse = ", ") else "—"
+
+        tibble(
+            baseline = baseline_label,
+            seas5_rp = rp,
+            n_years = nrow(df),
+            droughts_early = droughts_early,
+            total_droughts = n_drought,
+            pct_early = round(droughts_early / n_drought * 100, 0),
+            fp_total = fp_total,
+            fp_added = fp_added,
+            years_fp_added = years_added_str,
+            ratio = if (fp_added > 0) round(droughts_early / fp_added, 1) else droughts_early
+        )
+    })
+}
+
+# OPERATIONAL: Each baseline on its full period
+# 1984 baseline on all years (1984-2025)
+df_ew_1984_full <- calc_ew_metrics(df_comparison, "seas5_rp_1984", "1984-2025 (n=42)")
+
+# 1991 baseline on 1991+ years only
+df_comparison_1991 <- df_comparison |> filter(!is.na(seas5_rp_1991))
+df_ew_1991_full <- calc_ew_metrics(df_comparison_1991, "seas5_rp_1991", "1991-2025 (n=35)")
+
+df_ew_operational <- bind_rows(df_ew_1984_full, df_ew_1991_full)
+```
+
+### Operational Evaluation (Each Baseline on Full Record)
+
+```{r}
+#| label: early-warning-operational-table
+
+df_ew_operational |>
+    filter(seas5_rp %in% c(4, 6)) |>
+    select(baseline, seas5_rp, droughts_early, pct_early, fp_added, years_fp_added, ratio) |>
+    gt() |>
+    tab_header(
+        title = "SEAS5 Early Warning: Operational Performance",
+        subtitle = "Each baseline evaluated on its full record"
+    ) |>
+    cols_label(
+        baseline = "Baseline",
+        seas5_rp = "RP Threshold",
+        droughts_early = "Droughts Early",
+        pct_early = "% Early",
+        fp_added = "FP Added",
+        years_fp_added = "FP Years",
+        ratio = "Early:FP"
+    ) |>
+    tab_style(
+        style = cell_fill(color = "#FFF3E0"),
+        locations = cells_body(rows = seas5_rp == 4)
+    ) |>
+    tab_style(
+        style = cell_fill(color = "#F3E5F5"),
+        locations = cells_body(rows = seas5_rp == 6)
+    )
+```
+
+::: {.callout-warning}
+## Key Difference: 1985
+
+The 1984 baseline includes **1985** as an additional false positive at RP ≥ 4. This year is excluded from the 1991 baseline evaluation entirely because it falls outside that period. This means:
+
+- **1984 baseline, RP ≥ 4**: 2 FPs added (1985, 2010)
+- **1991 baseline, RP ≥ 4**: 1 FP added (2010 only)
+:::
+
+### Apples-to-Apples Comparison (Same Years)
+
+For a fair comparison of how the **baseline statistics** (mean/SD) affect rankings, we also evaluate both baselines on the **same years** (1991-2025, n=35):
+
+```{r}
+#| label: early-warning-same-years
+
+# Filter to years where both baselines have valid data (1991+)
+df_comparison_overlap <- df_comparison |>
+    filter(!is.na(seas5_rp_1991))
+
+n_years_overlap <- nrow(df_comparison_overlap)
+n_droughts_overlap <- sum(df_comparison_overlap$drought_actual == "yes")
+
+# Both baselines evaluated on the same overlapping years (1991-2025)
+df_ew_1984 <- calc_ew_metrics(df_comparison_overlap, "seas5_rp_1984", "1984-2025")
+df_ew_1991 <- calc_ew_metrics(df_comparison_overlap, "seas5_rp_1991", "1991-2025")
+
+df_ew_both <- bind_rows(df_ew_1984, df_ew_1991)
+```
+
+**Evaluation period**: `r n_years_overlap` years (1991-2025) with `r n_droughts_overlap` drought events.
+
+```{r}
+#| label: early-warning-table
+
+df_ew_both |>
+    select(baseline, seas5_rp, droughts_early, pct_early, fp_added, years_fp_added, ratio) |>
+    pivot_wider(
+        names_from = baseline,
+        values_from = c(droughts_early, pct_early, fp_added, years_fp_added, ratio),
+        names_glue = "{baseline}_{.value}"
+    ) |>
+    select(
+        seas5_rp,
+        `1984-2025_droughts_early`, `1991-2025_droughts_early`,
+        `1984-2025_pct_early`, `1991-2025_pct_early`,
+        `1984-2025_fp_added`, `1991-2025_fp_added`,
+        `1984-2025_ratio`, `1991-2025_ratio`
+    ) |>
+    gt() |>
+    tab_header(
+        title = "SEAS5 Early Warning Performance by Baseline",
+        subtitle = "Comparing 1984-2025 vs 1991-2025 climatology"
+    ) |>
+    tab_spanner(label = "Droughts Early", columns = contains("droughts_early")) |>
+    tab_spanner(label = "% Early", columns = contains("pct_early")) |>
+    tab_spanner(label = "FP Added", columns = contains("fp_added")) |>
+    tab_spanner(label = "Early:FP Ratio", columns = contains("ratio")) |>
+    cols_label(
+        seas5_rp = "SEAS5 RP",
+        `1984-2025_droughts_early` = "1984",
+        `1991-2025_droughts_early` = "1991",
+        `1984-2025_pct_early` = "1984",
+        `1991-2025_pct_early` = "1991",
+        `1984-2025_fp_added` = "1984",
+        `1991-2025_fp_added` = "1991",
+        `1984-2025_ratio` = "1984",
+        `1991-2025_ratio` = "1991"
+    )
+```
+
+```{r}
+#| label: early-warning-plot
+#| fig-height: 5
+#| fig-width: 10
+
+p_early <- df_ew_both |>
+    ggplot(aes(x = seas5_rp, y = droughts_early, color = baseline, group = baseline)) +
+    geom_line(linewidth = 1) +
+    geom_point(size = 3) +
+    scale_color_manual(values = c("1984-2025" = hdx_hex("sapphire-hdx"),
+                                   "1991-2025" = hdx_hex("tomato-hdx"))) +
+    scale_x_continuous(breaks = 3:7) +
+    labs(
+        title = "Droughts with Early Warning",
+        x = "SEAS5 RP Threshold",
+        y = "N Droughts",
+        color = "Baseline"
+    )
+
+p_ratio <- df_ew_both |>
+    ggplot(aes(x = seas5_rp, y = ratio, color = baseline, group = baseline)) +
+    geom_line(linewidth = 1) +
+    geom_point(size = 3) +
+    geom_hline(yintercept = 1, linetype = "dashed", color = "grey50") +
+    annotate("text", x = 7, y = 1, label = "1:1 break-even", hjust = 1, vjust = 1.5,
+             size = 3, color = "grey50") +
+    scale_color_manual(values = c("1984-2025" = hdx_hex("sapphire-hdx"),
+                                   "1991-2025" = hdx_hex("tomato-hdx"))) +
+    scale_x_continuous(breaks = 3:7) +
+    labs(
+        title = "Early Warning Value (Early:FP Added)",
+        x = "SEAS5 RP Threshold",
+        y = "Ratio",
+        color = "Baseline"
+    )
+
+p_early + p_ratio + plot_layout(guides = "collect") & theme(legend.position = "bottom")
+```
+
+### False Positives Added: Detail
+
+```{r}
+#| label: fp-added-detail
+
+# Show which years contribute FP under each baseline at RP4
+df_fp_detail <- df_ew_both |>
+    filter(seas5_rp == 4) |>
+    select(baseline, fp_added, years_fp_added)
+
+df_fp_detail |>
+    knitr::kable(
+        col.names = c("Baseline", "FP Added", "Years"),
+        caption = "False positives added by SEAS5 at RP >= 4 threshold"
+    )
+```
+
+**Verification: All years where SEAS5 (1991 baseline) fires at RP >= 4:**
+
+```{r}
+#| label: fp-verification
+
+# Show all years where SEAS5 1991 baseline fires, with their status
+df_comparison_overlap |>
+    filter(seas5_rp_1991 >= 4) |>
+    select(year, drought_actual, cdi_fires, seas5_fires_1991, cdi_rp, seas5_rp_1991) |>
+    mutate(
+        fp_added = !cdi_fires & drought_actual == "no",
+        category = case_when(
+            drought_actual == "yes" ~ "True Positive",
+            cdi_fires ~ "FP (already in CDI)",
+            TRUE ~ "FP Added by SEAS5"
+        )
+    ) |>
+    arrange(desc(year)) |>
+    knitr::kable(
+        col.names = c("Year", "Drought", "CDI Fires", "SEAS5 Fires", "CDI RP", "SEAS5 RP", "FP Added?", "Category"),
+        caption = "All years where SEAS5 (1991 baseline) fires at RP >= 4"
+    )
+```
+
+## Apples-to-Apples Comparison: Same RP Denominator
+
+The analysis above calculates RP within each baseline's full period (42 years for 1984, 35 years for 1991). This means RP4 represents slightly different percentiles. For a true apples-to-apples comparison, we recalculate RP for **both** baselines using only the **same 35 years** (1991-2025). This isolates the effect of the climatology choice (different mean/SD) on year rankings.
+
+```{r}
+#| label: same-denominator-rp
+
+# Recalculate RPs for both baselines using ONLY the 35 overlapping years
+df_same_denom <- df_comparison_overlap |>
+    mutate(
+        # Both RPs calculated on the same 35 years
+        seas5_rp_1984_same = rp_empirical(zscore_1984, direction = "-1"),
+        seas5_rp_1991_same = rp_empirical(zscore_1991, direction = "-1")
+    )
+
+# Check for disagreements under same-denominator RPs
+df_same_denom <- df_same_denom |>
+    mutate(
+        fires_1984_same = seas5_rp_1984_same >= 4,
+        fires_1991_same = seas5_rp_1991_same >= 4,
+        disagree_same = fires_1984_same != fires_1991_same
+    )
+
+n_disagree_same <- sum(df_same_denom$disagree_same, na.rm = TRUE)
+
+# Create full record (1984-2025) with 1991 baseline values as NA for pre-1991 years
+df_full_record <- df_comparison |>
+    left_join(
+        df_same_denom |> select(year, seas5_rp_1984_same, fires_1984_same,
+                                 seas5_rp_1991_same, fires_1991_same),
+        by = "year"
+    )
+```
+
+### Year-by-Year: Same Denominator
+
+```{r}
+#| label: same-denom-comparison
+
+df_full_record |>
+    select(year, drought_actual, cdi_rp, cdi_fires,
+           zscore_1984, seas5_rp_1984, fires_1984 = seas5_fires_1984,
+           zscore_1991, seas5_rp_1991_same, fires_1991_same) |>
+    arrange(desc(seas5_rp_1984)) |>
+    mutate(
+        is_pre_1991 = year < 1991,
+        # Blank out 1991 baseline values for pre-1991 years (misleading to show)
+        zscore_1991 = if_else(is_pre_1991, NA_real_, zscore_1991),
+        across(contains("zscore"), ~ round(.x, 2)),
+        across(contains("rp"), ~ round(.x, 1))
+    ) |>
+    gt() |>
+    cols_hide(columns = is_pre_1991) |>
+    sub_missing(missing_text = "") |>
+    tab_header(
+        title = "Full Record by SEAS5 Signal (1984-2025)",
+        subtitle = "Row colors: TP (teal), TN (light teal), FP (light salmon), FN (coral). Violet = SEAS5 fires when CDI doesn't."
+    ) |>
+    tab_spanner(label = "CDI (April)", columns = c(cdi_rp, cdi_fires)) |>
+    tab_spanner(label = "SEAS5 1984 Baseline (n=42)", columns = c(zscore_1984, seas5_rp_1984, fires_1984)) |>
+    tab_spanner(label = "SEAS5 1991 Baseline (n=35)", columns = c(zscore_1991, seas5_rp_1991_same, fires_1991_same)) |>
+    # TP: CDI fires AND drought = yes (teal)
+    tab_style(
+        style = cell_fill(color = "#1EBFB3"),
+        locations = cells_body(rows = cdi_fires == TRUE & drought_actual == "yes")
+    ) |>
+    # TN: CDI doesn't fire AND drought = no (light teal)
+    tab_style(
+        style = cell_fill(color = "#D2F2F0"),
+        locations = cells_body(rows = cdi_fires == FALSE & drought_actual == "no")
+    ) |>
+    # FN: CDI doesn't fire AND drought = yes (coral red)
+    tab_style(
+        style = cell_fill(color = "#F2645A"),
+        locations = cells_body(rows = cdi_fires == FALSE & drought_actual == "yes")
+    ) |>
+    # FP: CDI fires AND drought = no (light salmon)
+    tab_style(
+        style = cell_fill(color = "#F7A29C"),
+        locations = cells_body(rows = cdi_fires == TRUE & drought_actual == "no")
+    ) |>
+    # Light violet for SEAS5 columns when SEAS5 fires but CDI doesn't
+    tab_style(
+        style = cell_fill(color = "#E1BEE7"),  # light violet
+        locations = cells_body(
+            columns = c(zscore_1984, seas5_rp_1984, fires_1984),
+            rows = fires_1984 == TRUE & cdi_fires == FALSE
+        )
+    ) |>
+    tab_style(
+        style = cell_fill(color = "#E1BEE7"),  # light violet
+        locations = cells_body(
+            columns = c(zscore_1991, seas5_rp_1991_same, fires_1991_same),
+            rows = fires_1991_same == TRUE & cdi_fires == FALSE
+        )
+    ) |>
+    # Grey background for NA cells (pre-1991 years) - applied last to override row colors
+    tab_style(
+        style = cell_fill(color = "#E0E0E0"),
+        locations = cells_body(
+            columns = c(zscore_1991, seas5_rp_1991_same, fires_1991_same),
+            rows = is_pre_1991 == TRUE
+        )
+    ) |>
+    cols_label(
+        year = "Year",
+        drought_actual = "Drought",
+        cdi_rp = "RP",
+        cdi_fires = "Fires",
+        zscore_1984 = "Z-score",
+        seas5_rp_1984 = "RP",
+        fires_1984 = "Fires",
+        zscore_1991 = "Z-score",
+        seas5_rp_1991_same = "RP",
+        fires_1991_same = "Fires"
+    )
+```
+
+```{r}
+#| label: same-denom-disagree
+
+# Show disagreement years if any
+df_disagree_same <- df_same_denom |>
+    filter(disagree_same) |>
+    arrange(desc(year))
+
+if (nrow(df_disagree_same) > 0) {
+    df_disagree_same |>
+        select(year, drought_actual,
+               zscore_1984, seas5_rp_1984_same, fires_1984_same,
+               zscore_1991, seas5_rp_1991_same, fires_1991_same) |>
+        mutate(across(contains("zscore"), ~ round(.x, 2))) |>
+        mutate(across(contains("rp"), ~ round(.x, 1))) |>
+        gt() |>
+        tab_header(
+            title = "Years Where Baselines Disagree (Same RP Denominator)",
+            subtitle = "Different trigger decisions at RP >= 4"
+        ) |>
+        tab_spanner(label = "1984-2025 Baseline", columns = c(zscore_1984, seas5_rp_1984_same, fires_1984_same)) |>
+        tab_spanner(label = "1991-2025 Baseline", columns = c(zscore_1991, seas5_rp_1991_same, fires_1991_same)) |>
+        tab_style(
+            style = cell_fill(color = "tomato", alpha = 0.3),
+            locations = cells_body(columns = drought_actual, rows = drought_actual == "yes")
+        ) |>
+        cols_label(
+            year = "Year",
+            drought_actual = "Drought",
+            zscore_1984 = "Z-score",
+            seas5_rp_1984_same = "RP",
+            fires_1984_same = "Fires",
+            zscore_1991 = "Z-score",
+            seas5_rp_1991_same = "RP",
+            fires_1991_same = "Fires"
+        )
+} else {
+    cat("**No disagreements**: Both baselines trigger the same years at RP >= 4 when using the same 35-year denominator.")
+}
+```
+
+### Early Warning Performance: Same Denominator
+
+```{r}
+#| label: same-denom-ew-analysis
+
+# Calculate early warning metrics with same-denominator RPs
+df_ew_1984_same <- calc_ew_metrics(df_same_denom, "seas5_rp_1984_same", "1984-2025")
+df_ew_1991_same <- calc_ew_metrics(df_same_denom, "seas5_rp_1991_same", "1991-2025")
+
+df_ew_same <- bind_rows(df_ew_1984_same, df_ew_1991_same)
+```
+
+```{r}
+#| label: same-denom-ew-table
+
+df_ew_same |>
+    select(baseline, seas5_rp, droughts_early, pct_early, fp_added, ratio) |>
+    pivot_wider(
+        names_from = baseline,
+        values_from = c(droughts_early, pct_early, fp_added, ratio),
+        names_glue = "{baseline}_{.value}"
+    ) |>
+    select(
+        seas5_rp,
+        `1984-2025_droughts_early`, `1991-2025_droughts_early`,
+        `1984-2025_pct_early`, `1991-2025_pct_early`,
+        `1984-2025_fp_added`, `1991-2025_fp_added`,
+        `1984-2025_ratio`, `1991-2025_ratio`
+    ) |>
+    gt() |>
+    tab_header(
+        title = "SEAS5 Early Warning Performance (Same RP Denominator)",
+        subtitle = "Both baselines: RP calculated on 35 years (1991-2025)"
+    ) |>
+    tab_spanner(label = "Droughts Early", columns = contains("droughts_early")) |>
+    tab_spanner(label = "% Early", columns = contains("pct_early")) |>
+    tab_spanner(label = "FP Added", columns = contains("fp_added")) |>
+    tab_spanner(label = "Early:FP Ratio", columns = contains("ratio")) |>
+    cols_label(
+        seas5_rp = "SEAS5 RP",
+        `1984-2025_droughts_early` = "1984",
+        `1991-2025_droughts_early` = "1991",
+        `1984-2025_pct_early` = "1984",
+        `1991-2025_pct_early` = "1991",
+        `1984-2025_fp_added` = "1984",
+        `1991-2025_fp_added` = "1991",
+        `1984-2025_ratio` = "1984",
+        `1991-2025_ratio` = "1991"
+    )
+```
+
+```{r}
+#| label: same-denom-ew-plot
+#| fig-height: 5
+#| fig-width: 10
+
+p_early_same <- df_ew_same |>
+    ggplot(aes(x = seas5_rp, y = droughts_early, color = baseline, group = baseline)) +
+    geom_line(linewidth = 1) +
+    geom_point(size = 3) +
+    scale_color_manual(values = c("1984-2025" = hdx_hex("sapphire-hdx"),
+                                   "1991-2025" = hdx_hex("tomato-hdx"))) +
+    scale_x_continuous(breaks = 3:7) +
+    labs(
+        title = "Droughts with Early Warning",
+        subtitle = "Same RP denominator (35 years)",
+        x = "SEAS5 RP Threshold",
+        y = "N Droughts",
+        color = "Baseline"
+    )
+
+p_ratio_same <- df_ew_same |>
+    ggplot(aes(x = seas5_rp, y = ratio, color = baseline, group = baseline)) +
+    geom_line(linewidth = 1) +
+    geom_point(size = 3) +
+    geom_hline(yintercept = 1, linetype = "dashed", color = "grey50") +
+    annotate("text", x = 7, y = 1, label = "1:1 break-even", hjust = 1, vjust = 1.5,
+             size = 3, color = "grey50") +
+    scale_color_manual(values = c("1984-2025" = hdx_hex("sapphire-hdx"),
+                                   "1991-2025" = hdx_hex("tomato-hdx"))) +
+    scale_x_continuous(breaks = 3:7) +
+    labs(
+        title = "Early Warning Value (Early:FP Added)",
+        subtitle = "Same RP denominator (35 years)",
+        x = "SEAS5 RP Threshold",
+        y = "Ratio",
+        color = "Baseline"
+    )
+
+p_early_same + p_ratio_same + plot_layout(guides = "collect") & theme(legend.position = "bottom")
+```
+
+::: {.callout-note}
+## Same-Denominator Summary
+
+When both baselines use the **same 35-year period** for RP calculation:
+
+- **Trigger disagreements at RP >= 4**: `r n_disagree_same` year(s)
+- This isolates the effect of different climatology mean/SD on rankings
+- If disagreements exist, they reveal years where the baseline choice materially changes the trigger decision
+:::
+
+## Summary & Conclusion
+
+```{r}
+#| label: summary-stats
+
+# Key metrics at RP4 - original (different denominators)
+ew_1984_rp4 <- df_ew_1984 |> filter(seas5_rp == 4)
+ew_1991_rp4 <- df_ew_1991 |> filter(seas5_rp == 4)
+
+# Key metrics at RP4 - same denominator
+ew_1984_rp4_same <- df_ew_1984_same |> filter(seas5_rp == 4)
+ew_1991_rp4_same <- df_ew_1991_same |> filter(seas5_rp == 4)
+
+n_disagree <- sum(df_comparison$baseline_disagree, na.rm = TRUE)
+
+# Check if 1991 baseline is strictly better at any RP (same denominator)
+better_1991_same <- df_ew_same |>
+    select(seas5_rp, baseline, ratio) |>
+    pivot_wider(names_from = baseline, values_from = ratio) |>
+    mutate(diff = `1991-2025` - `1984-2025`) |>
+    filter(diff > 0) |>
+    nrow()
+
+better_1984_same <- df_ew_same |>
+    select(seas5_rp, baseline, ratio) |>
+    pivot_wider(names_from = baseline, values_from = ratio) |>
+    mutate(diff = `1984-2025` - `1991-2025`) |>
+    filter(diff > 0) |>
+    nrow()
+```
+::: {.callout-important}
+## Key Findings
+
+**Z-Score Correlation:** r = `r round(cor_zscores, 3)` — baseline choice produces highly correlated but systematically shifted z-scores.
+
+### Original Comparison (Different RP Denominators)
+
+RP calculated within each baseline's full period (42 vs 35 years).
+
+**Trigger Disagreement:** `r n_disagree` year(s) differ at RP >= 4.
+
+| Metric | 1984-2025 (n=42) | 1991-2025 (n=35) |
+|--------|------------------|------------------|
+| Droughts with early warning | `r ew_1984_rp4$droughts_early` | `r ew_1991_rp4$droughts_early` |
+| % Early | `r ew_1984_rp4$pct_early`% | `r ew_1991_rp4$pct_early`% |
+| FP Added | `r ew_1984_rp4$fp_added` | `r ew_1991_rp4$fp_added` |
+| Early:FP Ratio | `r ew_1984_rp4$ratio`:1 | `r ew_1991_rp4$ratio`:1 |
+
+### Apples-to-Apples Comparison (Same RP Denominator)
+
+Both baselines: RP calculated on the same 35 years (1991-2025).
+
+**Trigger Disagreement:** `r n_disagree_same` year(s) differ at RP >= 4.
+
+| Metric | 1984-2025 | 1991-2025 |
+|--------|-----------|-----------|
+| Droughts with early warning | `r ew_1984_rp4_same$droughts_early` | `r ew_1991_rp4_same$droughts_early` |
+| % Early | `r ew_1984_rp4_same$pct_early`% | `r ew_1991_rp4_same$pct_early`% |
+| FP Added | `r ew_1984_rp4_same$fp_added` | `r ew_1991_rp4_same$fp_added` |
+| Early:FP Ratio | `r ew_1984_rp4_same$ratio`:1 | `r ew_1991_rp4_same$ratio`:1 |
+
+:::
+
+::: {.callout-note}
+## Baseline Recommendation
+
+```{r}
+#| label: recommendation
+#| results: asis
+
+# Use same-denominator comparison for recommendation (fairer comparison)
+ratio_diff_same <- abs(ew_1984_rp4_same$ratio - ew_1991_rp4_same$ratio)
+
+if (ratio_diff_same < 0.5 && n_disagree_same <= 2) {
+    cat("The SEAS5 early warning performance is **robust to baseline choice**. Under the apples-to-apples comparison (same RP denominator), both baselines produce similar early warning value at RP >= 4. Given the minimal difference, **either baseline is acceptable**:\n\n")
+    cat("- **1991-2025**: Aligns with ECMWF's recommendation about pre-1991 data quality\n")
+    cat("- **1984-2025**: Maximizes consistency with CDI baseline\n")
+} else if (ew_1991_rp4_same$ratio > ew_1984_rp4_same$ratio) {
+    cat("The 1991-2025 baseline produces **better early warning performance** (higher early:FP ratio) under the apples-to-apples comparison. This supports ECMWF's concern about pre-1991 forecast quality.\n\n")
+    cat("**Recommend adopting 1991-2025 baseline for SEAS5** while keeping CDI on 1984-2025.")
+} else {
+    cat("The 1984-2025 baseline produces **better early warning performance** under the apples-to-apples comparison. Despite ECMWF's concerns about pre-1991 data, the different climatology (mean/SD) appears to produce better rankings for drought detection.\n\n")
+    cat("**Recommend retaining 1984-2025 baseline for SEAS5** for consistency with CDI.")
+}
+```
+:::
+
+## Framing the Choice: Two Equivalent Paths
+
+The analysis above demonstrates that the **baseline choice** (1984 vs 1991) has minimal impact on performance—the real decision is the **RP threshold** (4 vs 6). A lower threshold (RP≥4) provides more early warnings but adds a false positive; a higher threshold (RP≥6) improves precision but sacrifices early warning coverage.
+
+### The Core Insight
+
+SEAS5 serves one purpose: **early warning**. It fires one month before CDI (March vs April), giving humanitarian actors additional lead time. The CDI remains the primary, higher-confidence trigger. Any year that CDI catches, the Combined trigger catches. SEAS5 only matters for the subset of droughts where it provides that extra month.
+
+### Option A: 1991-2025 Baseline with RP ≥ 4
+
+**Narrative:** *"We use SEAS5 forecasts from 1991 onward, following ECMWF guidance about pre-1991 data quality. A 1-in-4 year forecast anomaly triggers early warning."*
+
+| Aspect | Implication |
+|--------|-------------|
+| **Scientific defensibility** | Aligns with ECMWF's documented concerns about pre-1991 hindcast quality |
+| **Threshold consistency** | Both CDI (~RP4) and SEAS5 (RP4) use the same return period—simple to communicate |
+| **Historical record** | 35 years (1991-2025) for SEAS5 evaluation |
+| **Messaging** | "1-in-4 year event" is intuitive and matches CDI framing |
+
+### Option B: 1984-2025 Baseline with RP ≥ 6
+
+**Narrative:** *"We use the full 42-year SEAS5 record to maximize sample size. A higher threshold (1-in-6 year) compensates for potential noise in early forecasts."*
+
+| Aspect | Implication |
+|--------|-------------|
+| **Scientific defensibility** | Maximizes sample size; higher threshold implicitly down-weights noisy early years |
+| **Threshold consistency** | CDI uses ~RP4, SEAS5 uses RP6—requires explanation of why they differ |
+| **Historical record** | 42 years (1984-2025) for SEAS5 evaluation |
+| **Messaging** | "1-in-6 year event" sounds more conservative but requires explaining the asymmetry |
+
+### Option C: 1991-2025 Baseline with RP ≥ 6
+
+**Narrative:** *"We use the reliable forecast period (1991+) AND a conservative threshold. This is our most stringent early warning criterion."*
+
+| Aspect | Implication |
+|--------|-------------|
+| **Scientific defensibility** | Most conservative: reliable data + high threshold |
+| **Threshold consistency** | CDI uses ~RP4, SEAS5 uses RP6—still requires explaining asymmetry |
+| **Historical record** | 35 years (1991-2025) for SEAS5 evaluation |
+| **Messaging** | Very conservative; may miss early warning opportunities |
+
+### What Actually Differs?
+
+```{r}
+#| label: what-differs
+
+# Compare all three configurations on 1991-2025 period (where all have valid data)
+df_config_compare <- df_same_denom |>
+    mutate(
+        # Option A: 1991 baseline, RP4
+        fires_a = seas5_rp_1991_same >= 4,
+        # Option B: 1984 baseline, RP6 (use 1984 z-scores, same-denom RP)
+        fires_b = seas5_rp_1984_same >= 6,
+        # Option C: 1991 baseline, RP6
+        fires_c = seas5_rp_1991_same >= 6
+    )
+
+# Early warning metrics for each option
+calc_option_metrics <- function(df, fires_col, label) {
+    fires <- df[[fires_col]]
+    droughts_early <- sum(fires & df$drought_actual == "yes", na.rm = TRUE)
+    fp_added <- sum(fires & !df$cdi_fires & df$drought_actual == "no", na.rm = TRUE)
+    n_drought <- sum(df$drought_actual == "yes", na.rm = TRUE)
+    n_triggers <- sum(fires, na.rm = TRUE)
+
+    # Combined metrics
+    combined <- fires | df$cdi_fires
+    combined_tp <- sum(combined & df$drought_actual == "yes", na.rm = TRUE)
+    combined_fp <- sum(combined & df$drought_actual == "no", na.rm = TRUE)
+    combined_fn <- sum(!combined & df$drought_actual == "yes", na.rm = TRUE)
+
+    tibble(
+        option = label,
+        seas5_triggers = n_triggers,
+        droughts_early = droughts_early,
+        pct_early = round(droughts_early / n_drought * 100, 0),
+        fp_added = fp_added,
+        ratio = if (fp_added > 0) paste0(droughts_early, ":", fp_added) else paste0(droughts_early, ":0"),
+        combined_tp = combined_tp,
+        combined_fp = combined_fp,
+        combined_fn = combined_fn,
+        combined_f1 = round(2 * combined_tp / (2 * combined_tp + combined_fp + combined_fn), 2)
+    )
+}
+
+df_options <- bind_rows(
+    calc_option_metrics(df_config_compare, "fires_a", "A: 1991 baseline, RP ≥ 4"),
+    calc_option_metrics(df_config_compare, "fires_b", "B: 1984 baseline, RP ≥ 6"),
+    calc_option_metrics(df_config_compare, "fires_c", "C: 1991 baseline, RP ≥ 6")
+)
+```
+
+### Three-Way Comparison (1991-2025 evaluation period)
+
+```{r}
+#| label: three-way-table
+
+df_options |>
+    gt() |>
+    tab_header(
+        title = "SEAS5 Early Warning: Three Configuration Options",
+        subtitle = "All evaluated on 1991-2025 (n=35 years, 10 droughts)"
+    ) |>
+    tab_spanner(label = "SEAS5 Standalone", columns = c(seas5_triggers, droughts_early, pct_early, fp_added, ratio)) |>
+    tab_spanner(label = "Combined Trigger (OR)", columns = c(combined_tp, combined_fp, combined_fn, combined_f1)) |>
+    cols_label(
+        option = "Configuration",
+        seas5_triggers = "Triggers",
+        droughts_early = "Early Warnings",
+        pct_early = "% Droughts",
+        fp_added = "FP Added",
+        ratio = "Early:FP",
+        combined_tp = "TP",
+        combined_fp = "FP",
+        combined_fn = "FN",
+        combined_f1 = "F1"
+    ) |>
+    tab_style(
+        style = cell_fill(color = "#D2F2F0"),
+        locations = cells_body(rows = 1)
+    ) |>
+    tab_footnote(
+        footnote = "FP Added = false positives from SEAS5 that CDI doesn't already trigger",
+        locations = cells_column_labels(columns = fp_added)
+    )
+```
+
+```{r}
+#| label: years-by-option
+
+# Show which years each option triggers (SEAS5 only, not CDI)
+df_years_by_option <- df_config_compare |>
+    select(year, drought_actual, cdi_fires, fires_a, fires_b, fires_c,
+           seas5_rp_1991_same, seas5_rp_1984_same) |>
+    filter(fires_a | fires_b | fires_c) |>
+    arrange(desc(seas5_rp_1991_same))
+
+df_years_by_option |>
+    mutate(
+        seas5_rp_1991_same = round(seas5_rp_1991_same, 1),
+        seas5_rp_1984_same = round(seas5_rp_1984_same, 1),
+        early_warning = !cdi_fires & drought_actual == "yes",
+        fp_added = !cdi_fires & drought_actual == "no"
+    ) |>
+    select(year, drought_actual, cdi_fires, seas5_rp_1991_same, fires_a, fires_c,
+           seas5_rp_1984_same, fires_b, early_warning, fp_added) |>
+    gt() |>
+    tab_header(
+        title = "Years Triggered by Each SEAS5 Configuration",
+        subtitle = "Green = early warning value (SEAS5 fires, CDI doesn't, drought occurs)"
+    ) |>
+    tab_spanner(label = "1991 Baseline", columns = c(seas5_rp_1991_same, fires_a, fires_c)) |>
+    tab_spanner(label = "1984 Baseline", columns = c(seas5_rp_1984_same, fires_b)) |>
+    cols_label(
+        year = "Year",
+        drought_actual = "Drought",
+        cdi_fires = "CDI",
+        seas5_rp_1991_same = "RP",
+        fires_a = "RP≥4",
+        fires_c = "RP≥6",
+        seas5_rp_1984_same = "RP",
+        fires_b = "RP≥6",
+        early_warning = "Early Warn",
+        fp_added = "FP Added"
+    ) |>
+    tab_style(
+        style = cell_fill(color = "#1EBFB3"),
+        locations = cells_body(rows = drought_actual == "yes")
+    ) |>
+    tab_style(
+        style = cell_fill(color = "#F7A29C"),
+        locations = cells_body(rows = drought_actual == "no")
+    ) |>
+    tab_style(
+        style = cell_fill(color = "#E1BEE7"),
+        locations = cells_body(columns = c(early_warning), rows = early_warning == TRUE)
+    ) |>
+    cols_hide(columns = c(early_warning, fp_added))
+```
+
+### The Real Tradeoff
+
+The table above reveals that **Options B and C produce identical results**—at RP≥6, the baseline choice doesn't matter. The real decision is between **RP≥4 vs RP≥6**:
+
+| Choice | Early Warnings | FP Added | Combined F1 | Effective RP |
+|--------|---------------|----------|-------------|--------------|
+| **RP ≥ 4** | 6/10 (60%) | 1 | 0.82 | ~3 years |
+| **RP ≥ 6** | 4/10 (40%) | 0 | 0.86 | ~3.6 years |
+
+**The question**: Is getting **2 additional early warnings** worth **1 false positive** and a small F1 reduction?
+
+### Recommendation
+
+::: {.callout-tip}
+## Preferred: Option A (1991-2025 baseline, RP ≥ 4)
+
+**Rationale:**
+
+1. **Early warning is the whole point**: SEAS5 exists to provide lead time. At RP6, we lose 2 of our 6 early warnings (33% reduction) to avoid 1 false positive.
+2. **6:1 ratio is excellent**: Getting 6 early warnings for 1 added FP is a strong value proposition for humanitarian preparedness.
+3. **Simpler communication**: Both CDI and SEAS5 use ~RP4 threshold—one number for stakeholders.
+4. **Scientific alignment**: Follows ECMWF guidance on SEAS5 hindcast reliability (1991+).
+
+**The counterargument for RP≥6 (Options B/C):**
+
+- Higher Combined F1 (0.86 vs 0.82)
+- Zero added false positives
+- More conservative = fewer false alarms
+
+Choose RP≥6 if the cost of a false positive outweighs the value of 2 additional early warnings. Choose RP≥4 if early warning lead time is the priority.
+:::
+
+## Final Trigger Recommendation
+
+Based on the analysis in this chapter and the preceding trigger modeling chapters, we recommend the following two-stage trigger system:
+
+```{r}
+#| label: final-trigger-summary
+
+# Get CDI metrics
+n_years_total <- nrow(df_cdi)
+n_droughts_total <- sum(df_cdi$drought_actual == "yes")
+n_cdi_triggers <- sum(cdi_fires)
+cdi_tp <- sum(cdi_fires & df_cdi$drought_actual == "yes")
+cdi_fp <- sum(cdi_fires & df_cdi$drought_actual == "no")
+cdi_fn <- sum(!cdi_fires & df_cdi$drought_actual == "yes")
+cdi_precision <- round(cdi_tp / (cdi_tp + cdi_fp), 2)
+cdi_recall <- round(cdi_tp / (cdi_tp + cdi_fn), 2)
+cdi_f1 <- round(2 * cdi_precision * cdi_recall / (cdi_precision + cdi_recall), 2)
+cdi_rp_effective <- round((n_years_total + 1) / n_cdi_triggers, 1)
+
+# Combined trigger metrics
+# Use df_same_denom (1991-2025, n=35) where both SEAS5 baselines have same-denominator RPs
+# This ensures consistent evaluation period and RP calculation for SEAS5 and Combined
+df_combined_eval <- df_same_denom |>
+    mutate(
+        # Use 1984 baseline z-scores with RP calculated on 35-year period (same denom)
+        seas5_fires_rp4 = seas5_rp_1984_same >= 4,
+        combined_fires = cdi_fires | seas5_fires_rp4
+    )
+
+n_combined_triggers <- sum(df_combined_eval$combined_fires, na.rm = TRUE)
+combined_tp <- sum(df_combined_eval$combined_fires & df_combined_eval$drought_actual == "yes", na.rm = TRUE)
+combined_fp <- sum(df_combined_eval$combined_fires & df_combined_eval$drought_actual == "no", na.rm = TRUE)
+combined_fn <- sum(!df_combined_eval$combined_fires & df_combined_eval$drought_actual == "yes", na.rm = TRUE)
+combined_precision <- round(combined_tp / (combined_tp + combined_fp), 2)
+combined_recall <- round(combined_tp / (combined_tp + combined_fn), 2)
+combined_f1 <- round(2 * combined_precision * combined_recall / (combined_precision + combined_recall), 2)
+n_years_combined <- nrow(df_combined_eval)
+combined_rp_effective <- round((n_years_combined + 1) / n_combined_triggers, 1)
+```
+
+::: {.callout-important}
+## Recommended Trigger Configuration
+
+### Two-Stage Trigger (OR Logic)
+
+| Stage | Signal | Timing | Threshold | Purpose |
+|-------|--------|--------|-----------|---------|
+| **1. Early Warning** | SEAS5 MAM Forecast | March | RP ≥ 4 | Early mobilization (1 month lead) |
+| **2. Confirmation** | Ridge-based CDI | April | F1-optimized (~RP 4) | Higher confidence trigger |
+
+A year triggers if **either** stage fires.
+
+### Baseline Periods
+
+| Component | Baseline | Rationale |
+|-----------|----------|-----------|
+| CDI | 1984-2025 | Maximize sample size; ASI/ERA5 observations reliable |
+| SEAS5 | 1984-2025 or 1991-2025 | Either acceptable; results robust to choice |
+:::
+
+### Performance Characteristics
+
+```{r}
+#| label: performance-table
+
+# Helper function to format count with years in parentheses
+format_with_years <- function(count, years) {
+    if (count == 0) return("0")
+    paste0(count, " (", paste(sort(years), collapse = ", "), ")")
+}
+
+# ============================================================================
+# CDI years for FP and FN
+# ============================================================================
+cdi_fp_years <- df_cdi$year[cdi_fires & df_cdi$drought_actual == "no"]
+cdi_fn_years <- df_cdi$year[!cdi_fires & df_cdi$drought_actual == "yes"]
+cdi_fp_str <- format_with_years(cdi_fp, cdi_fp_years)
+cdi_fn_str <- format_with_years(cdi_fn, cdi_fn_years)
+
+# ============================================================================
+# Configuration A: 1991-2025 (n=35), SEAS5 RP >= 4
+# ============================================================================
+n_droughts_combined <- sum(df_combined_eval$drought_actual == "yes")
+
+# SEAS5 Only metrics (Config A)
+seas5_fires_a <- df_combined_eval$seas5_fires_rp4
+n_seas5_triggers_a <- sum(seas5_fires_a, na.rm = TRUE)
+seas5_tp_a <- sum(seas5_fires_a & df_combined_eval$drought_actual == "yes", na.rm = TRUE)
+seas5_fp_a <- sum(seas5_fires_a & df_combined_eval$drought_actual == "no", na.rm = TRUE)
+seas5_fn_a <- sum(!seas5_fires_a & df_combined_eval$drought_actual == "yes", na.rm = TRUE)
+seas5_precision_a <- round(seas5_tp_a / (seas5_tp_a + seas5_fp_a), 2)
+seas5_recall_a <- round(seas5_tp_a / (seas5_tp_a + seas5_fn_a), 2)
+seas5_f1_a <- round(2 * seas5_precision_a * seas5_recall_a / (seas5_precision_a + seas5_recall_a), 2)
+seas5_rp_effective_a <- round((n_years_combined + 1) / n_seas5_triggers_a, 1)
+
+# Extract years for Config A SEAS5
+seas5_fp_years_a <- df_combined_eval$year[seas5_fires_a & df_combined_eval$drought_actual == "no"]
+seas5_fn_years_a <- df_combined_eval$year[!seas5_fires_a & df_combined_eval$drought_actual == "yes"]
+seas5_fp_str_a <- format_with_years(seas5_fp_a, seas5_fp_years_a)
+seas5_fn_str_a <- format_with_years(seas5_fn_a, seas5_fn_years_a)
+
+# Extract years for Config A Combined
+combined_fp_years_a <- df_combined_eval$year[df_combined_eval$combined_fires & df_combined_eval$drought_actual == "no"]
+combined_fn_years_a <- df_combined_eval$year[!df_combined_eval$combined_fires & df_combined_eval$drought_actual == "yes"]
+combined_fp_str_a <- format_with_years(combined_fp, combined_fp_years_a)
+combined_fn_str_a <- format_with_years(combined_fn, combined_fn_years_a)
+
+# ============================================================================
+# Configuration B: 1984-2025 (n=42), SEAS5 RP >= 6
+# ============================================================================
+# Use df_comparison filtered to all years with valid 1984 baseline RP
+df_eval_1984 <- df_comparison |>
+    filter(!is.na(seas5_rp_1984)) |>
+    mutate(
+        cdi_fires = cdi >= cdi_threshold,
+        seas5_fires_rp6 = seas5_rp_1984 >= 6,
+        combined_fires = cdi_fires | seas5_fires_rp6
+    )
+
+n_years_1984 <- nrow(df_eval_1984)
+n_droughts_1984 <- sum(df_eval_1984$drought_actual == "yes")
+
+# SEAS5 Only metrics (Config B: RP >= 6)
+seas5_fires_b <- df_eval_1984$seas5_fires_rp6
+n_seas5_triggers_b <- sum(seas5_fires_b, na.rm = TRUE)
+seas5_tp_b <- sum(seas5_fires_b & df_eval_1984$drought_actual == "yes", na.rm = TRUE)
+seas5_fp_b <- sum(seas5_fires_b & df_eval_1984$drought_actual == "no", na.rm = TRUE)
+seas5_fn_b <- sum(!seas5_fires_b & df_eval_1984$drought_actual == "yes", na.rm = TRUE)
+seas5_precision_b <- round(seas5_tp_b / (seas5_tp_b + seas5_fp_b), 2)
+seas5_recall_b <- round(seas5_tp_b / (seas5_tp_b + seas5_fn_b), 2)
+seas5_f1_b <- round(2 * seas5_precision_b * seas5_recall_b / (seas5_precision_b + seas5_recall_b), 2)
+seas5_rp_effective_b <- round((n_years_1984 + 1) / n_seas5_triggers_b, 1)
+
+# Combined metrics (Config B)
+n_combined_triggers_b <- sum(df_eval_1984$combined_fires, na.rm = TRUE)
+combined_tp_b <- sum(df_eval_1984$combined_fires & df_eval_1984$drought_actual == "yes", na.rm = TRUE)
+combined_fp_b <- sum(df_eval_1984$combined_fires & df_eval_1984$drought_actual == "no", na.rm = TRUE)
+combined_fn_b <- sum(!df_eval_1984$combined_fires & df_eval_1984$drought_actual == "yes", na.rm = TRUE)
+combined_precision_b <- round(combined_tp_b / (combined_tp_b + combined_fp_b), 2)
+combined_recall_b <- round(combined_tp_b / (combined_tp_b + combined_fn_b), 2)
+combined_f1_b <- round(2 * combined_precision_b * combined_recall_b / (combined_precision_b + combined_recall_b), 2)
+combined_rp_effective_b <- round((n_years_1984 + 1) / n_combined_triggers_b, 1)
+
+# ============================================================================
+# Configuration C: 1991-2025 (n=35), SEAS5 RP >= 6
+# ============================================================================
+df_eval_1991_rp6 <- df_same_denom |>
+    mutate(
+        seas5_fires_rp6 = seas5_rp_1991_same >= 6,
+        combined_fires_c = cdi_fires | seas5_fires_rp6
+    )
+
+# SEAS5 Only metrics (Config C: 1991 baseline, RP >= 6)
+seas5_fires_c <- df_eval_1991_rp6$seas5_fires_rp6
+n_seas5_triggers_c <- sum(seas5_fires_c, na.rm = TRUE)
+seas5_tp_c <- sum(seas5_fires_c & df_eval_1991_rp6$drought_actual == "yes", na.rm = TRUE)
+seas5_fp_c <- sum(seas5_fires_c & df_eval_1991_rp6$drought_actual == "no", na.rm = TRUE)
+seas5_fn_c <- sum(!seas5_fires_c & df_eval_1991_rp6$drought_actual == "yes", na.rm = TRUE)
+seas5_precision_c <- round(seas5_tp_c / (seas5_tp_c + seas5_fp_c), 2)
+seas5_recall_c <- round(seas5_tp_c / (seas5_tp_c + seas5_fn_c), 2)
+seas5_f1_c <- round(2 * seas5_precision_c * seas5_recall_c / (seas5_precision_c + seas5_recall_c), 2)
+seas5_rp_effective_c <- round((n_years_combined + 1) / n_seas5_triggers_c, 1)
+
+# Combined metrics (Config C)
+n_combined_triggers_c <- sum(df_eval_1991_rp6$combined_fires_c, na.rm = TRUE)
+combined_tp_c <- sum(df_eval_1991_rp6$combined_fires_c & df_eval_1991_rp6$drought_actual == "yes", na.rm = TRUE)
+combined_fp_c <- sum(df_eval_1991_rp6$combined_fires_c & df_eval_1991_rp6$drought_actual == "no", na.rm = TRUE)
+combined_fn_c <- sum(!df_eval_1991_rp6$combined_fires_c & df_eval_1991_rp6$drought_actual == "yes", na.rm = TRUE)
+combined_precision_c <- round(combined_tp_c / (combined_tp_c + combined_fp_c), 2)
+combined_recall_c <- round(combined_tp_c / (combined_tp_c + combined_fn_c), 2)
+combined_f1_c <- round(2 * combined_precision_c * combined_recall_c / (combined_precision_c + combined_recall_c), 2)
+combined_rp_effective_c <- round((n_years_combined + 1) / n_combined_triggers_c, 1)
+
+# ============================================================================
+# Build combined comparison table
+# ============================================================================
+tibble(
+    Metric = c(
+        "Evaluation period",
+        "Drought years",
+        "Years triggered",
+        "True positives",
+        "False positives",
+        "Missed droughts",
+        "Precision",
+        "Recall",
+        "F1 Score",
+        "Effective RP"
+    ),
+    # CDI Only (same for both configs)
+    cdi = c(
+        paste0(n_years_total, " (1984-2025)"),
+        as.character(n_droughts_total),
+        as.character(n_cdi_triggers),
+        as.character(cdi_tp),
+        as.character(cdi_fp),
+        as.character(cdi_fn),
+        as.character(cdi_precision),
+        as.character(cdi_recall),
+        as.character(cdi_f1),
+        paste0("~", cdi_rp_effective, " yr")
+    ),
+    # Config A: 1991-2025, RP4
+    seas5_a = c(
+        paste0(n_years_combined, " (1991-2025)"),
+        as.character(n_droughts_combined),
+        as.character(n_seas5_triggers_a),
+        as.character(seas5_tp_a),
+        as.character(seas5_fp_a),
+        as.character(seas5_fn_a),
+        as.character(seas5_precision_a),
+        as.character(seas5_recall_a),
+        as.character(seas5_f1_a),
+        paste0("~", seas5_rp_effective_a, " yr")
+    ),
+    combined_a = c(
+        paste0(n_years_combined, " (1991-2025)"),
+        as.character(n_droughts_combined),
+        as.character(n_combined_triggers),
+        as.character(combined_tp),
+        as.character(combined_fp),
+        as.character(combined_fn),
+        as.character(combined_precision),
+        as.character(combined_recall),
+        as.character(combined_f1),
+        paste0("~", combined_rp_effective, " yr")
+    ),
+    # Config B: 1984-2025, RP6
+    seas5_b = c(
+        paste0(n_years_1984, " (1984-2025)"),
+        as.character(n_droughts_1984),
+        as.character(n_seas5_triggers_b),
+        as.character(seas5_tp_b),
+        as.character(seas5_fp_b),
+        as.character(seas5_fn_b),
+        as.character(seas5_precision_b),
+        as.character(seas5_recall_b),
+        as.character(seas5_f1_b),
+        paste0("~", seas5_rp_effective_b, " yr")
+    ),
+    combined_b = c(
+        paste0(n_years_1984, " (1984-2025)"),
+        as.character(n_droughts_1984),
+        as.character(n_combined_triggers_b),
+        as.character(combined_tp_b),
+        as.character(combined_fp_b),
+        as.character(combined_fn_b),
+        as.character(combined_precision_b),
+        as.character(combined_recall_b),
+        as.character(combined_f1_b),
+        paste0("~", combined_rp_effective_b, " yr")
+    ),
+    # Config C: 1991-2025, RP6
+    seas5_c = c(
+        paste0(n_years_combined, " (1991-2025)"),
+        as.character(n_droughts_combined),
+        as.character(n_seas5_triggers_c),
+        as.character(seas5_tp_c),
+        as.character(seas5_fp_c),
+        as.character(seas5_fn_c),
+        as.character(seas5_precision_c),
+        as.character(seas5_recall_c),
+        as.character(seas5_f1_c),
+        paste0("~", seas5_rp_effective_c, " yr")
+    ),
+    combined_c = c(
+        paste0(n_years_combined, " (1991-2025)"),
+        as.character(n_droughts_combined),
+        as.character(n_combined_triggers_c),
+        as.character(combined_tp_c),
+        as.character(combined_fp_c),
+        as.character(combined_fn_c),
+        as.character(combined_precision_c),
+        as.character(combined_recall_c),
+        as.character(combined_f1_c),
+        paste0("~", combined_rp_effective_c, " yr")
+    )
+) |>
+    gt() |>
+    tab_header(
+        title = "Trigger Performance Comparison",
+        subtitle = "Three configurations: 1991 RP≥4, 1984 RP≥6, 1991 RP≥6"
+    ) |>
+    tab_spanner(
+        label = "CDI Only (April)",
+        columns = cdi
+    ) |>
+    tab_spanner(
+        label = "1991, RP ≥ 4",
+        columns = c(seas5_a, combined_a)
+    ) |>
+    tab_spanner(
+        label = "1984, RP ≥ 6",
+        columns = c(seas5_b, combined_b)
+    ) |>
+    tab_spanner(
+        label = "1991, RP ≥ 6",
+        columns = c(seas5_c, combined_c)
+    ) |>
+    # Column group colors - softer palette
+    tab_style(
+        style = cell_fill(color = "#D2F2F0"),  # light teal for CDI
+        locations = cells_body(columns = cdi)
+    ) |>
+    tab_style(
+        style = cell_fill(color = "#D2F2F0"),
+        locations = cells_column_labels(columns = cdi)
+    ) |>
+    tab_style(
+        style = cell_fill(color = "#FFF8E1"),  # very light amber for Config A
+        locations = cells_body(columns = c(seas5_a, combined_a))
+    ) |>
+    tab_style(
+        style = cell_fill(color = "#FFF8E1"),
+        locations = cells_column_labels(columns = c(seas5_a, combined_a))
+    ) |>
+    tab_style(
+        style = cell_fill(color = "#F3E5F5"),  # light violet for Config B
+        locations = cells_body(columns = c(seas5_b, combined_b))
+    ) |>
+    tab_style(
+        style = cell_fill(color = "#F3E5F5"),
+        locations = cells_column_labels(columns = c(seas5_b, combined_b))
+    ) |>
+    # Config C styling - light blue for third config
+    tab_style(
+        style = cell_fill(color = "#E3F2FD"),  # light blue for Config C
+        locations = cells_body(columns = c(seas5_c, combined_c))
+    ) |>
+    tab_style(
+        style = cell_fill(color = "#E3F2FD"),
+        locations = cells_column_labels(columns = c(seas5_c, combined_c))
+    ) |>
+    # Style the spanner headers
+    tab_style(
+        style = list(
+            cell_fill(color = "#1EBFB3"),
+            cell_text(weight = "bold", size = px(13)),
+            cell_borders(sides = c("left", "right"), color = "white", weight = px(2))
+        ),
+        locations = cells_column_spanners(spanners = "CDI Only (April)")
+    ) |>
+    tab_style(
+        style = list(
+            cell_fill(color = "#FFCC80"),
+            cell_text(weight = "bold", size = px(13)),
+            cell_borders(sides = c("left", "right"), color = "white", weight = px(2))
+        ),
+        locations = cells_column_spanners(spanners = "1991, RP ≥ 4")
+    ) |>
+    tab_style(
+        style = list(
+            cell_fill(color = "#CE93D8"),
+            cell_text(weight = "bold", size = px(13)),
+            cell_borders(sides = c("left", "right"), color = "white", weight = px(2))
+        ),
+        locations = cells_column_spanners(spanners = "1984, RP ≥ 6")
+    ) |>
+    tab_style(
+        style = list(
+            cell_fill(color = "#64B5F6"),  # blue for Config C spanner
+            cell_text(weight = "bold", size = px(13)),
+            cell_borders(sides = c("left", "right"), color = "white", weight = px(2))
+        ),
+        locations = cells_column_spanners(spanners = "1991, RP ≥ 6")
+    ) |>
+    # Add vertical borders between column groups
+    tab_style(
+        style = cell_borders(sides = "right", color = "#9E9E9E", weight = px(2)),
+        locations = cells_body(columns = cdi)
+    ) |>
+    tab_style(
+        style = cell_borders(sides = "right", color = "#9E9E9E", weight = px(2)),
+        locations = cells_body(columns = combined_a)
+    ) |>
+    tab_style(
+        style = cell_borders(sides = "right", color = "#9E9E9E", weight = px(2)),
+        locations = cells_body(columns = combined_b)
+    ) |>
+    cols_label(
+        Metric = "",
+        cdi = "CDI",
+        seas5_a = "SEAS5",
+        combined_a = "Combined",
+        seas5_b = "SEAS5",
+        combined_b = "Combined",
+        seas5_c = "SEAS5",
+        combined_c = "Combined"
+    )
+```
+
+### SEAS5 Early Warning Value
+
+Beyond standalone performance, SEAS5 adds value by providing **one month earlier warning** for droughts that CDI would eventually catch anyway.
+
+```{r}
+#| label: seas5-value-add
+
+tibble(
+    Metric = c(
+        "Droughts with early warning",
+        "Extra FP from SEAS5",
+        "Early:FP ratio"
+    ),
+    Value = c(
+        paste0(ew_1984_rp4_same$droughts_early, "/", ew_1984_rp4_same$total_droughts, " (", ew_1984_rp4_same$pct_early, "%)"),
+        as.character(ew_1984_rp4_same$fp_added),
+        paste0(ew_1984_rp4_same$ratio, ":1")
+    )
+) |>
+    gt() |>
+    tab_header(
+        title = "SEAS5 Early Warning Value-Add",
+        subtitle = "Additional benefit when used alongside CDI (1991-2025)"
+    )
+```
+
+::: {.callout-note}
+## Interpretation
+
+**CDI (April trigger)** is the primary trigger with strong performance (evaluated on full 1984-2025 record):
+
+- Captures `r cdi_recall * 100`% of droughts (`r cdi_tp`/`r n_droughts_total`)
+- Precision of `r cdi_precision * 100`% (`r cdi_fp` false positive(s) in `r n_years_total` years)
+- F1 score of `r cdi_f1`
+
+**SEAS5 (March early warning)** adds value without degrading precision (evaluated on 1991-2025):
+
+- Provides **one month earlier warning** for `r ew_1984_rp4_same$pct_early`% of droughts
+- Adds only `r ew_1984_rp4_same$fp_added` false positive(s) beyond CDI
+- Excellent `r ew_1984_rp4_same$ratio`:1 early warning to false positive ratio
+
+**Combined trigger** maintains the target activation frequency (evaluated on 1991-2025 where both signals available):
+
+- Effective return period of ~`r combined_rp_effective` years (within RP 3-5 target)
+- OR logic ensures no drought is missed if either signal fires
+- `r combined_recall * 100`% recall with `r combined_precision * 100`% precision
+
+:::
+
+### Operational Timeline
+
+```{r}
+#| label: timeline
+#| fig-height: 3
+#| fig-width: 8
+
+timeline_df <- tibble(
+    stage = factor(c("SEAS5 Check", "CDI Check", "Action Window"),
+                   levels = c("SEAS5 Check", "CDI Check", "Action Window")),
+    start = as.Date(c("2026-03-01", "2026-04-01", "2026-03-15")),
+    end = as.Date(c("2026-03-15", "2026-04-15", "2026-05-31")),
+    type = c("trigger", "trigger", "action")
+)
+
+ggplot(timeline_df, aes(y = stage)) +
+    geom_segment(aes(x = start, xend = end, yend = stage, color = type),
+                 linewidth = 8, lineend = "round") +
+    geom_vline(xintercept = as.Date("2026-03-01"), linetype = "dashed", color = "grey50") +
+    geom_vline(xintercept = as.Date("2026-04-01"), linetype = "dashed", color = "grey50") +
+    annotate("text", x = as.Date("2026-03-01"), y = 0.5, label = "Mar 1",
+             vjust = -0.5, size = 3, color = "grey50") +
+    annotate("text", x = as.Date("2026-04-01"), y = 0.5, label = "Apr 1",
+             vjust = -0.5, size = 3, color = "grey50") +
+    scale_x_date(date_labels = "%b %d", date_breaks = "2 weeks",
+                 limits = as.Date(c("2026-02-15", "2026-06-15"))) +
+    scale_color_manual(values = c("trigger" = hdx_hex("sapphire-hdx"),
+                                   "action" = hdx_hex("mint-hdx")),
+                       guide = "none") +
+    labs(
+        title = "Trigger Timeline",
+        subtitle = "Two decision points with overlapping action window",
+        x = NULL, y = NULL
+    ) +
+    theme(
+        panel.grid.major.y = element_blank(),
+        panel.grid.minor = element_blank()
+    )
+```
+
+**March (SEAS5)**: If SEAS5 MAM forecast exceeds RP4 threshold → early mobilization begins
+
+**April (CDI)**: If CDI exceeds F1-optimized threshold → trigger confirmed (or newly triggered if SEAS5 didn't fire)

--- a/book_afg_analysis/15_baseline_sensitivity.qmd
+++ b/book_afg_analysis/15_baseline_sensitivity.qmd
@@ -605,7 +605,9 @@ calc_ew_metrics <- function(df, seas5_rp_col, baseline_label) {
             fp_total = fp_total,
             fp_added = fp_added,
             years_fp_added = years_added_str,
-            ratio = if (fp_added > 0) round(droughts_early / fp_added, 1) else droughts_early
+            # When fp_added = 0, ratio is infinite (use Inf for plotting)
+            ratio = if (fp_added > 0) round(droughts_early / fp_added, 1) else Inf,
+            ratio_label = if (fp_added > 0) as.character(round(droughts_early / fp_added, 1)) else paste0(droughts_early, ":0")
         )
     })
 }
@@ -628,7 +630,7 @@ df_ew_operational <- bind_rows(df_ew_1984_full, df_ew_1991_full)
 
 df_ew_operational |>
     filter(seas5_rp %in% c(4, 6)) |>
-    select(baseline, seas5_rp, droughts_early, pct_early, fp_added, years_fp_added, ratio) |>
+    select(baseline, seas5_rp, droughts_early, pct_early, fp_added, years_fp_added, ratio_label) |>
     gt() |>
     tab_header(
         title = "SEAS5 Early Warning: Operational Performance",
@@ -641,7 +643,7 @@ df_ew_operational |>
         pct_early = "% Early",
         fp_added = "FP Added",
         years_fp_added = "FP Years",
-        ratio = "Early:FP"
+        ratio_label = "Early:FP"
     ) |>
     tab_style(
         style = cell_fill(color = "#FFF3E0"),
@@ -676,23 +678,23 @@ df_comparison_overlap <- df_comparison |>
 n_years_overlap <- nrow(df_comparison_overlap)
 n_droughts_overlap <- sum(df_comparison_overlap$drought_actual == "yes")
 
-# Both baselines evaluated on the same overlapping years (1991-2025)
-df_ew_1984 <- calc_ew_metrics(df_comparison_overlap, "seas5_rp_1984", "1984-2025")
-df_ew_1991 <- calc_ew_metrics(df_comparison_overlap, "seas5_rp_1991", "1991-2025")
-
-df_ew_both <- bind_rows(df_ew_1984, df_ew_1991)
+# Use operational evaluation: each baseline on its FULL period
+# This correctly shows 1984 baseline has 2 FPs at RP4 (1985, 2010)
+# Clean up baseline labels for table
+df_ew_both <- df_ew_operational |>
+    mutate(baseline = gsub(" \\(n=\\d+\\)", "", baseline))
 ```
 
-**Evaluation period**: `r n_years_overlap` years (1991-2025) with `r n_droughts_overlap` drought events.
+**Evaluation period**: Each baseline evaluated on its full record (1984-2025: 42 years, 11 droughts; 1991-2025: 35 years, 10 droughts).
 
 ```{r}
 #| label: early-warning-table
 
 df_ew_both |>
-    select(baseline, seas5_rp, droughts_early, pct_early, fp_added, years_fp_added, ratio) |>
+    select(baseline, seas5_rp, droughts_early, pct_early, fp_added, years_fp_added, ratio_label) |>
     pivot_wider(
         names_from = baseline,
-        values_from = c(droughts_early, pct_early, fp_added, years_fp_added, ratio),
+        values_from = c(droughts_early, pct_early, fp_added, years_fp_added, ratio_label),
         names_glue = "{baseline}_{.value}"
     ) |>
     select(
@@ -700,17 +702,17 @@ df_ew_both |>
         `1984-2025_droughts_early`, `1991-2025_droughts_early`,
         `1984-2025_pct_early`, `1991-2025_pct_early`,
         `1984-2025_fp_added`, `1991-2025_fp_added`,
-        `1984-2025_ratio`, `1991-2025_ratio`
+        `1984-2025_ratio_label`, `1991-2025_ratio_label`
     ) |>
     gt() |>
     tab_header(
         title = "SEAS5 Early Warning Performance by Baseline",
-        subtitle = "Comparing 1984-2025 vs 1991-2025 climatology"
+        subtitle = "Each baseline evaluated on its full record"
     ) |>
     tab_spanner(label = "Droughts Early", columns = contains("droughts_early")) |>
     tab_spanner(label = "% Early", columns = contains("pct_early")) |>
     tab_spanner(label = "FP Added", columns = contains("fp_added")) |>
-    tab_spanner(label = "Early:FP Ratio", columns = contains("ratio")) |>
+    tab_spanner(label = "Early:FP Ratio", columns = contains("ratio_label")) |>
     cols_label(
         seas5_rp = "SEAS5 RP",
         `1984-2025_droughts_early` = "1984",
@@ -719,8 +721,8 @@ df_ew_both |>
         `1991-2025_pct_early` = "1991",
         `1984-2025_fp_added` = "1984",
         `1991-2025_fp_added` = "1991",
-        `1984-2025_ratio` = "1984",
-        `1991-2025_ratio` = "1991"
+        `1984-2025_ratio_label` = "1984",
+        `1991-2025_ratio_label` = "1991"
     )
 ```
 
@@ -730,12 +732,13 @@ df_ew_both |>
 #| fig-width: 10
 
 p_early <- df_ew_both |>
+    filter(seas5_rp <= 6) |>
     ggplot(aes(x = seas5_rp, y = droughts_early, color = baseline, group = baseline)) +
     geom_line(linewidth = 1) +
     geom_point(size = 3) +
     scale_color_manual(values = c("1984-2025" = hdx_hex("sapphire-hdx"),
                                    "1991-2025" = hdx_hex("tomato-hdx"))) +
-    scale_x_continuous(breaks = 3:7) +
+    scale_x_continuous(breaks = 3:6) +
     labs(
         title = "Droughts with Early Warning",
         x = "SEAS5 RP Threshold",
@@ -743,18 +746,52 @@ p_early <- df_ew_both |>
         color = "Baseline"
     )
 
-p_ratio <- df_ew_both |>
-    ggplot(aes(x = seas5_rp, y = ratio, color = baseline, group = baseline)) +
-    geom_line(linewidth = 1) +
-    geom_point(size = 3) +
+# Filter to RP 3-6, identify infinite ratios
+df_ratio_plot <- df_ew_both |>
+    filter(seas5_rp <= 6) |>
+    mutate(is_inf = is.infinite(ratio))
+
+# Separate finite points (for line/dots) and infinite points (for curve to ∞)
+df_finite <- df_ratio_plot |> filter(!is_inf)
+df_inf <- df_ratio_plot |> filter(is_inf)
+
+# For baselines that go to infinity at RP 6: get the last finite point to start curve
+# Only for baselines that have infinite ratio at RP 6
+baselines_with_inf <- df_inf$baseline
+df_curve_start <- df_finite |>
+    filter(baseline %in% baselines_with_inf) |>
+    group_by(baseline) |>
+    filter(seas5_rp == max(seas5_rp)) |>
+    ungroup()
+
+# Arrow endpoint
+y_max <- max(df_finite$ratio, na.rm = TRUE)
+y_arrow <- y_max + 3
+
+p_ratio <- ggplot() +
+    # Main line and points for all finite data
+    geom_line(data = df_finite,
+              aes(x = seas5_rp, y = ratio, color = baseline, group = baseline),
+              linewidth = 1) +
+    geom_point(data = df_finite,
+               aes(x = seas5_rp, y = ratio, color = baseline), size = 3) +
+    # Curved arrow ONLY for baselines with infinite ratio at RP 6
+    geom_curve(data = df_curve_start,
+               aes(x = seas5_rp, y = ratio, xend = 6, yend = y_arrow, color = baseline),
+               curvature = 0.3, linewidth = 1,
+               arrow = arrow(length = unit(0.12, "inches"), type = "closed"),
+               show.legend = FALSE) +
+    # ∞ label (only if there are infinite points)
+    {if(nrow(df_inf) > 0) annotate("text", x = 6.08, y = y_arrow, label = "∞", size = 6, fontface = "bold")} +
     geom_hline(yintercept = 1, linetype = "dashed", color = "grey50") +
-    annotate("text", x = 7, y = 1, label = "1:1 break-even", hjust = 1, vjust = 1.5,
-             size = 3, color = "grey50") +
+    annotate("text", x = 5.9, y = 1.4, label = "1:1 break-even", hjust = 1, size = 3, color = "grey50") +
     scale_color_manual(values = c("1984-2025" = hdx_hex("sapphire-hdx"),
                                    "1991-2025" = hdx_hex("tomato-hdx"))) +
-    scale_x_continuous(breaks = 3:7) +
+    scale_x_continuous(breaks = 3:6, limits = c(3, 6.3)) +
+    coord_cartesian(ylim = c(0, y_arrow + 1.5)) +
     labs(
         title = "Early Warning Value (Early:FP Added)",
+        subtitle = "1991 baseline: zero FPs at RP ≥ 6 (ratio → ∞)",
         x = "SEAS5 RP Threshold",
         y = "Ratio",
         color = "Baseline"
@@ -979,10 +1016,10 @@ df_ew_same <- bind_rows(df_ew_1984_same, df_ew_1991_same)
 #| label: same-denom-ew-table
 
 df_ew_same |>
-    select(baseline, seas5_rp, droughts_early, pct_early, fp_added, ratio) |>
+    select(baseline, seas5_rp, droughts_early, pct_early, fp_added, ratio_label) |>
     pivot_wider(
         names_from = baseline,
-        values_from = c(droughts_early, pct_early, fp_added, ratio),
+        values_from = c(droughts_early, pct_early, fp_added, ratio_label),
         names_glue = "{baseline}_{.value}"
     ) |>
     select(
@@ -990,7 +1027,7 @@ df_ew_same |>
         `1984-2025_droughts_early`, `1991-2025_droughts_early`,
         `1984-2025_pct_early`, `1991-2025_pct_early`,
         `1984-2025_fp_added`, `1991-2025_fp_added`,
-        `1984-2025_ratio`, `1991-2025_ratio`
+        `1984-2025_ratio_label`, `1991-2025_ratio_label`
     ) |>
     gt() |>
     tab_header(
@@ -1000,7 +1037,7 @@ df_ew_same |>
     tab_spanner(label = "Droughts Early", columns = contains("droughts_early")) |>
     tab_spanner(label = "% Early", columns = contains("pct_early")) |>
     tab_spanner(label = "FP Added", columns = contains("fp_added")) |>
-    tab_spanner(label = "Early:FP Ratio", columns = contains("ratio")) |>
+    tab_spanner(label = "Early:FP Ratio", columns = contains("ratio_label")) |>
     cols_label(
         seas5_rp = "SEAS5 RP",
         `1984-2025_droughts_early` = "1984",
@@ -1009,8 +1046,8 @@ df_ew_same |>
         `1991-2025_pct_early` = "1991",
         `1984-2025_fp_added` = "1984",
         `1991-2025_fp_added` = "1991",
-        `1984-2025_ratio` = "1984",
-        `1991-2025_ratio` = "1991"
+        `1984-2025_ratio_label` = "1984",
+        `1991-2025_ratio_label` = "1991"
     )
 ```
 
@@ -1020,12 +1057,13 @@ df_ew_same |>
 #| fig-width: 10
 
 p_early_same <- df_ew_same |>
+    filter(seas5_rp <= 6) |>
     ggplot(aes(x = seas5_rp, y = droughts_early, color = baseline, group = baseline)) +
     geom_line(linewidth = 1) +
     geom_point(size = 3) +
     scale_color_manual(values = c("1984-2025" = hdx_hex("sapphire-hdx"),
                                    "1991-2025" = hdx_hex("tomato-hdx"))) +
-    scale_x_continuous(breaks = 3:7) +
+    scale_x_continuous(breaks = 3:6) +
     labs(
         title = "Droughts with Early Warning",
         subtitle = "Same RP denominator (35 years)",
@@ -1034,19 +1072,47 @@ p_early_same <- df_ew_same |>
         color = "Baseline"
     )
 
-p_ratio_same <- df_ew_same |>
-    ggplot(aes(x = seas5_rp, y = ratio, color = baseline, group = baseline)) +
-    geom_line(linewidth = 1) +
-    geom_point(size = 3) +
+# Filter to RP 3-6, separate finite and infinite
+df_ratio_same_plot <- df_ew_same |>
+    filter(seas5_rp <= 6) |>
+    mutate(is_inf = is.infinite(ratio))
+
+df_finite_same <- df_ratio_same_plot |> filter(!is_inf)
+df_inf_same <- df_ratio_same_plot |> filter(is_inf)
+
+# Only curve to infinity for baselines that have infinite ratio at RP 6
+baselines_with_inf_same <- df_inf_same$baseline
+df_curve_start_same <- df_finite_same |>
+    filter(baseline %in% baselines_with_inf_same) |>
+    group_by(baseline) |>
+    filter(seas5_rp == max(seas5_rp)) |>
+    ungroup()
+
+y_max_same <- max(df_finite_same$ratio, na.rm = TRUE)
+y_arrow_same <- y_max_same + 3
+
+p_ratio_same <- ggplot() +
+    geom_line(data = df_finite_same,
+              aes(x = seas5_rp, y = ratio, color = baseline, group = baseline),
+              linewidth = 1) +
+    geom_point(data = df_finite_same,
+               aes(x = seas5_rp, y = ratio, color = baseline), size = 3) +
+    # Curved arrow ONLY for baselines with infinite ratio at RP 6
+    geom_curve(data = df_curve_start_same,
+               aes(x = seas5_rp, y = ratio, xend = 6, yend = y_arrow_same, color = baseline),
+               curvature = 0.3, linewidth = 1,
+               arrow = arrow(length = unit(0.12, "inches"), type = "closed"),
+               show.legend = FALSE) +
+    {if(nrow(df_inf_same) > 0) annotate("text", x = 6.08, y = y_arrow_same, label = "∞", size = 6, fontface = "bold")} +
     geom_hline(yintercept = 1, linetype = "dashed", color = "grey50") +
-    annotate("text", x = 7, y = 1, label = "1:1 break-even", hjust = 1, vjust = 1.5,
-             size = 3, color = "grey50") +
+    annotate("text", x = 5.9, y = 1.4, label = "1:1 break-even", hjust = 1, size = 3, color = "grey50") +
     scale_color_manual(values = c("1984-2025" = hdx_hex("sapphire-hdx"),
                                    "1991-2025" = hdx_hex("tomato-hdx"))) +
-    scale_x_continuous(breaks = 3:7) +
+    scale_x_continuous(breaks = 3:6, limits = c(3, 6.3)) +
+    coord_cartesian(ylim = c(0, y_arrow_same + 1.5)) +
     labs(
         title = "Early Warning Value (Early:FP Added)",
-        subtitle = "Same RP denominator (35 years)",
+        subtitle = "Same RP denominator (35 years) — At RP ≥ 6: ratio → ∞",
         x = "SEAS5 RP Threshold",
         y = "Ratio",
         color = "Baseline"
@@ -1070,9 +1136,9 @@ When both baselines use the **same 35-year period** for RP calculation:
 ```{r}
 #| label: summary-stats
 
-# Key metrics at RP4 - original (different denominators)
-ew_1984_rp4 <- df_ew_1984 |> filter(seas5_rp == 4)
-ew_1991_rp4 <- df_ew_1991 |> filter(seas5_rp == 4)
+# Key metrics at RP4 - operational (each baseline on its full period)
+ew_1984_rp4 <- df_ew_both |> filter(baseline == "1984-2025", seas5_rp == 4)
+ew_1991_rp4 <- df_ew_both |> filter(baseline == "1991-2025", seas5_rp == 4)
 
 # Key metrics at RP4 - same denominator
 ew_1984_rp4_same <- df_ew_1984_same |> filter(seas5_rp == 4)
@@ -1507,6 +1573,18 @@ combined_recall_b <- round(combined_tp_b / (combined_tp_b + combined_fn_b), 2)
 combined_f1_b <- round(2 * combined_precision_b * combined_recall_b / (combined_precision_b + combined_recall_b), 2)
 combined_rp_effective_b <- round((n_years_1984 + 1) / n_combined_triggers_b, 1)
 
+# Extract years for Config B SEAS5
+seas5_fp_years_b <- df_eval_1984$year[seas5_fires_b & df_eval_1984$drought_actual == "no"]
+seas5_fn_years_b <- df_eval_1984$year[!seas5_fires_b & df_eval_1984$drought_actual == "yes"]
+seas5_fp_str_b <- format_with_years(seas5_fp_b, seas5_fp_years_b)
+seas5_fn_str_b <- format_with_years(seas5_fn_b, seas5_fn_years_b)
+
+# Extract years for Config B Combined
+combined_fp_years_b <- df_eval_1984$year[df_eval_1984$combined_fires & df_eval_1984$drought_actual == "no"]
+combined_fn_years_b <- df_eval_1984$year[!df_eval_1984$combined_fires & df_eval_1984$drought_actual == "yes"]
+combined_fp_str_b <- format_with_years(combined_fp_b, combined_fp_years_b)
+combined_fn_str_b <- format_with_years(combined_fn_b, combined_fn_years_b)
+
 # ============================================================================
 # Configuration C: 1991-2025 (n=35), SEAS5 RP >= 6
 # ============================================================================
@@ -1537,6 +1615,27 @@ combined_recall_c <- round(combined_tp_c / (combined_tp_c + combined_fn_c), 2)
 combined_f1_c <- round(2 * combined_precision_c * combined_recall_c / (combined_precision_c + combined_recall_c), 2)
 combined_rp_effective_c <- round((n_years_combined + 1) / n_combined_triggers_c, 1)
 
+# Extract years for Config C SEAS5
+seas5_fp_years_c <- df_eval_1991_rp6$year[seas5_fires_c & df_eval_1991_rp6$drought_actual == "no"]
+seas5_fn_years_c <- df_eval_1991_rp6$year[!seas5_fires_c & df_eval_1991_rp6$drought_actual == "yes"]
+seas5_fp_str_c <- format_with_years(seas5_fp_c, seas5_fp_years_c)
+seas5_fn_str_c <- format_with_years(seas5_fn_c, seas5_fn_years_c)
+
+# Extract years for Config C Combined
+combined_fp_years_c <- df_eval_1991_rp6$year[df_eval_1991_rp6$combined_fires_c & df_eval_1991_rp6$drought_actual == "no"]
+combined_fn_years_c <- df_eval_1991_rp6$year[!df_eval_1991_rp6$combined_fires_c & df_eval_1991_rp6$drought_actual == "yes"]
+combined_fp_str_c <- format_with_years(combined_fp_c, combined_fp_years_c)
+combined_fn_str_c <- format_with_years(combined_fn_c, combined_fn_years_c)
+
+# ============================================================================
+# Calculate FPs ADDED by SEAS5 (beyond CDI) for interpretation
+# ============================================================================
+# Config A: SEAS5 FPs that are not already CDI FPs
+seas5_fp_added_a <- sum(seas5_fires_a & !df_combined_eval$cdi_fires & df_combined_eval$drought_actual == "no", na.rm = TRUE)
+
+# Config C: SEAS5 FPs that are not already CDI FPs
+seas5_fp_added_c <- sum(seas5_fires_c & !df_eval_1991_rp6$cdi_fires & df_eval_1991_rp6$drought_actual == "no", na.rm = TRUE)
+
 # ============================================================================
 # Build combined comparison table
 # ============================================================================
@@ -1559,8 +1658,8 @@ tibble(
         as.character(n_droughts_total),
         as.character(n_cdi_triggers),
         as.character(cdi_tp),
-        as.character(cdi_fp),
-        as.character(cdi_fn),
+        cdi_fp_str,
+        cdi_fn_str,
         as.character(cdi_precision),
         as.character(cdi_recall),
         as.character(cdi_f1),
@@ -1572,8 +1671,8 @@ tibble(
         as.character(n_droughts_combined),
         as.character(n_seas5_triggers_a),
         as.character(seas5_tp_a),
-        as.character(seas5_fp_a),
-        as.character(seas5_fn_a),
+        seas5_fp_str_a,
+        seas5_fn_str_a,
         as.character(seas5_precision_a),
         as.character(seas5_recall_a),
         as.character(seas5_f1_a),
@@ -1584,8 +1683,8 @@ tibble(
         as.character(n_droughts_combined),
         as.character(n_combined_triggers),
         as.character(combined_tp),
-        as.character(combined_fp),
-        as.character(combined_fn),
+        combined_fp_str_a,
+        combined_fn_str_a,
         as.character(combined_precision),
         as.character(combined_recall),
         as.character(combined_f1),
@@ -1597,8 +1696,8 @@ tibble(
         as.character(n_droughts_1984),
         as.character(n_seas5_triggers_b),
         as.character(seas5_tp_b),
-        as.character(seas5_fp_b),
-        as.character(seas5_fn_b),
+        seas5_fp_str_b,
+        seas5_fn_str_b,
         as.character(seas5_precision_b),
         as.character(seas5_recall_b),
         as.character(seas5_f1_b),
@@ -1609,8 +1708,8 @@ tibble(
         as.character(n_droughts_1984),
         as.character(n_combined_triggers_b),
         as.character(combined_tp_b),
-        as.character(combined_fp_b),
-        as.character(combined_fn_b),
+        combined_fp_str_b,
+        combined_fn_str_b,
         as.character(combined_precision_b),
         as.character(combined_recall_b),
         as.character(combined_f1_b),
@@ -1622,8 +1721,8 @@ tibble(
         as.character(n_droughts_combined),
         as.character(n_seas5_triggers_c),
         as.character(seas5_tp_c),
-        as.character(seas5_fp_c),
-        as.character(seas5_fn_c),
+        seas5_fp_str_c,
+        seas5_fn_str_c,
         as.character(seas5_precision_c),
         as.character(seas5_recall_c),
         as.character(seas5_f1_c),
@@ -1634,8 +1733,8 @@ tibble(
         as.character(n_droughts_combined),
         as.character(n_combined_triggers_c),
         as.character(combined_tp_c),
-        as.character(combined_fp_c),
-        as.character(combined_fn_c),
+        combined_fp_str_c,
+        combined_fn_str_c,
         as.character(combined_precision_c),
         as.character(combined_recall_c),
         as.character(combined_f1_c),
@@ -1790,60 +1889,14 @@ tibble(
 - Precision of `r cdi_precision * 100`% (`r cdi_fp` false positive(s) in `r n_years_total` years)
 - F1 score of `r cdi_f1`
 
-**SEAS5 (March early warning)** adds value without degrading precision (evaluated on 1991-2025):
+**SEAS5 (March early warning)** provides lead time options (evaluated on 1991-2025):
 
-- Provides **one month earlier warning** for `r ew_1984_rp4_same$pct_early`% of droughts
-- Adds only `r ew_1984_rp4_same$fp_added` false positive(s) beyond CDI
-- Excellent `r ew_1984_rp4_same$ratio`:1 early warning to false positive ratio
+- **RP ≥ 4**: Identifies `r seas5_recall_a * 100`% of droughts (`r seas5_tp_a`/`r n_droughts_combined`) with `r seas5_fp_added_a` FP(s) added beyond CDI
+- **RP ≥ 6**: Identifies `r seas5_recall_c * 100`% of droughts (`r seas5_tp_c`/`r n_droughts_combined`) with `r seas5_fp_added_c` FP(s) added beyond CDI
 
-**Combined trigger** maintains the target activation frequency (evaluated on 1991-2025 where both signals available):
+**Combined trigger (CDI OR SEAS5)** performance depends on SEAS5 threshold (evaluated on 1991-2025):
 
-- Effective return period of ~`r combined_rp_effective` years (within RP 3-5 target)
-- OR logic ensures no drought is missed if either signal fires
-- `r combined_recall * 100`% recall with `r combined_precision * 100`% precision
+- **With SEAS5 RP ≥ 4**: `r combined_recall * 100`% recall, `r combined_precision * 100`% precision, F1 = `r combined_f1`
+- **With SEAS5 RP ≥ 6**: `r combined_recall_c * 100`% recall, `r combined_precision_c * 100`% precision, F1 = `r combined_f1_c`
 
 :::
-
-### Operational Timeline
-
-```{r}
-#| label: timeline
-#| fig-height: 3
-#| fig-width: 8
-
-timeline_df <- tibble(
-    stage = factor(c("SEAS5 Check", "CDI Check", "Action Window"),
-                   levels = c("SEAS5 Check", "CDI Check", "Action Window")),
-    start = as.Date(c("2026-03-01", "2026-04-01", "2026-03-15")),
-    end = as.Date(c("2026-03-15", "2026-04-15", "2026-05-31")),
-    type = c("trigger", "trigger", "action")
-)
-
-ggplot(timeline_df, aes(y = stage)) +
-    geom_segment(aes(x = start, xend = end, yend = stage, color = type),
-                 linewidth = 8, lineend = "round") +
-    geom_vline(xintercept = as.Date("2026-03-01"), linetype = "dashed", color = "grey50") +
-    geom_vline(xintercept = as.Date("2026-04-01"), linetype = "dashed", color = "grey50") +
-    annotate("text", x = as.Date("2026-03-01"), y = 0.5, label = "Mar 1",
-             vjust = -0.5, size = 3, color = "grey50") +
-    annotate("text", x = as.Date("2026-04-01"), y = 0.5, label = "Apr 1",
-             vjust = -0.5, size = 3, color = "grey50") +
-    scale_x_date(date_labels = "%b %d", date_breaks = "2 weeks",
-                 limits = as.Date(c("2026-02-15", "2026-06-15"))) +
-    scale_color_manual(values = c("trigger" = hdx_hex("sapphire-hdx"),
-                                   "action" = hdx_hex("mint-hdx")),
-                       guide = "none") +
-    labs(
-        title = "Trigger Timeline",
-        subtitle = "Two decision points with overlapping action window",
-        x = NULL, y = NULL
-    ) +
-    theme(
-        panel.grid.major.y = element_blank(),
-        panel.grid.minor = element_blank()
-    )
-```
-
-**March (SEAS5)**: If SEAS5 MAM forecast exceeds RP4 threshold → early mobilization begins
-
-**April (CDI)**: If CDI exceeds F1-optimized threshold → trigger confirmed (or newly triggered if SEAS5 didn't fire)

--- a/book_afg_analysis/15_baseline_sensitivity.qmd
+++ b/book_afg_analysis/15_baseline_sensitivity.qmd
@@ -800,6 +800,129 @@ p_ratio <- ggplot() +
 p_early + p_ratio + plot_layout(guides = "collect") & theme(legend.position = "bottom")
 ```
 
+### Simplified View: 1991 Baseline Only
+
+This plot shows the tradeoff more directly using only the recommended 1991-2025 baseline:
+
+```{r}
+#| label: early-warning-1991-only
+#| fig-height: 5
+#| fig-width: 12
+
+# Filter to just 1991 baseline
+df_1991_only <- df_ew_both |>
+    filter(baseline == "1991-2025", seas5_rp <= 7)
+
+df_1991_long <- df_1991_only |>
+    select(seas5_rp, droughts_early, fp_added) |>
+    pivot_longer(
+        cols = c(droughts_early, fp_added),
+        names_to = "metric",
+        values_to = "count"
+    ) |>
+    mutate(
+        metric = case_when(
+            metric == "droughts_early" ~ "Droughts with early warning",
+            metric == "fp_added" ~ "False positives added"
+        ),
+        metric = factor(metric, levels = c("Droughts with early warning", "False positives added"))
+    )
+
+# Left plot: counts
+p_counts_1991 <- ggplot(df_1991_long, aes(x = seas5_rp, y = count, color = metric, group = metric)) +
+    geom_line(linewidth = 1.2) +
+    geom_point(size = 4) +
+    geom_text(
+        aes(label = count),
+        vjust = -1, size = 4, fontface = "bold", show.legend = FALSE
+    ) +
+    scale_color_manual(
+        values = c(
+            "Droughts with early warning" = hdx_hex("mint-hdx"),
+            "False positives added" = hdx_hex("tomato-hdx")
+        ),
+        name = NULL
+    ) +
+    scale_x_continuous(breaks = 3:7) +
+    scale_y_continuous(limits = c(-0.5, 8), breaks = 0:8) +
+    geom_hline(yintercept = 0, color = "grey70") +
+    labs(
+        title = "Early Warnings & False Positives",
+        x = "SEAS5 RP Threshold",
+        y = "Count (years)"
+    ) +
+    theme(
+        legend.position = "top",
+        plot.title = element_text(size = 14, face = "bold"),
+        axis.text = element_text(size = 11),
+        axis.title = element_text(size = 12)
+    )
+
+# Right plot: ratio with curved arrow to infinity
+df_ratio_1991 <- df_1991_only |>
+    filter(seas5_rp <= 6) |>
+    mutate(is_inf = is.infinite(ratio))
+
+df_finite_1991 <- df_ratio_1991 |> filter(!is_inf)
+df_inf_1991 <- df_ratio_1991 |> filter(is_inf)
+
+# Get last finite point for curve start
+df_curve_start_1991 <- df_finite_1991 |>
+    filter(seas5_rp == max(seas5_rp))
+
+y_max_1991 <- max(df_finite_1991$ratio, na.rm = TRUE)
+y_arrow_1991 <- y_max_1991 + 3
+
+p_ratio_1991 <- ggplot() +
+    # Main line and points for finite data
+    geom_line(data = df_finite_1991,
+              aes(x = seas5_rp, y = ratio),
+              color = hdx_hex("sapphire-hdx"), linewidth = 1.2) +
+    geom_point(data = df_finite_1991,
+               aes(x = seas5_rp, y = ratio),
+               color = hdx_hex("sapphire-hdx"), size = 4) +
+    # Curved arrow to infinity
+    geom_curve(data = df_curve_start_1991,
+               aes(x = seas5_rp, y = ratio, xend = 6, yend = y_arrow_1991),
+               color = hdx_hex("sapphire-hdx"),
+               curvature = 0.3, linewidth = 1.2,
+               arrow = arrow(length = unit(0.15, "inches"), type = "closed")) +
+    # ∞ label
+    annotate("text", x = 6.1, y = y_arrow_1991, label = "∞",
+             size = 8, fontface = "bold", color = hdx_hex("sapphire-hdx")) +
+    scale_x_continuous(breaks = 3:6, limits = c(3, 6.5)) +
+    coord_cartesian(ylim = c(0, y_arrow_1991 + 2)) +
+    labs(
+        title = "Early Warning Value (Early:FP Ratio)",
+        subtitle = "Zero FPs at RP ≥ 6 → ratio goes to ∞",
+        x = "SEAS5 RP Threshold",
+        y = "Ratio (Early Warnings : FPs Added)"
+    ) +
+    theme(
+        plot.title = element_text(size = 14, face = "bold"),
+        plot.subtitle = element_text(size = 11, color = "grey40"),
+        axis.text = element_text(size = 11),
+        axis.title = element_text(size = 12)
+    )
+
+p_counts_1991 + p_ratio_1991 +
+    plot_annotation(
+        title = "SEAS5 Early Warning Tradeoff (1991-2025 Baseline)",
+        theme = theme(plot.title = element_text(size = 16, face = "bold"))
+    )
+```
+
+::: {.callout-tip}
+## Key Takeaway
+
+With the **1991-2025 baseline**:
+
+- **RP ≥ 4**: 6 droughts get early warning, but adds 1 false positive (2010)
+- **RP ≥ 6**: 4 droughts get early warning, with **zero** false positives added
+
+The RP ≥ 6 threshold eliminates false positives while still providing early warning for 40% of droughts.
+:::
+
 ### False Positives Added: Detail
 
 ```{r}
@@ -1052,7 +1175,8 @@ df_ew_same |>
 ```
 
 ```{r}
-#| label: same-denom-ew-plot
+#| label: fig-seas5-early-warning
+#| fig-cap: "Droughts with Early Warning by SEAS5 Threshold"
 #| fig-height: 5
 #| fig-width: 10
 
@@ -1118,7 +1242,25 @@ p_ratio_same <- ggplot() +
         color = "Baseline"
     )
 
-p_early_same + p_ratio_same + plot_layout(guides = "collect") & theme(legend.position = "bottom")
+p_seas5_early_warning <- p_early_same + p_ratio_same + plot_layout(guides = "collect") & theme(legend.position = "bottom")
+
+ggsave("outputs/figures/fig-seas5-early-warning.png", p_seas5_early_warning, width = 10, height = 5, dpi = 300)
+
+# Paper version with larger text
+paper_theme <- theme(
+    text = element_text(size = 14),
+    axis.title = element_text(size = 14),
+    axis.text = element_text(size = 12),
+    plot.title = element_text(size = 16),
+    plot.subtitle = element_text(size = 13),
+    legend.text = element_text(size = 12),
+    legend.title = element_text(size = 13),
+    legend.position = "bottom"
+)
+p_seas5_paper <- (p_early_same + paper_theme) + (p_ratio_same + paper_theme) + plot_layout(guides = "collect")
+ggsave("outputs/figures/paper/fig-seas5-early-warning.png", p_seas5_paper, width = 10, height = 5, dpi = 300)
+
+p_seas5_early_warning
 ```
 
 ::: {.callout-note}

--- a/book_afg_analysis/16_performance_comparison.qmd
+++ b/book_afg_analysis/16_performance_comparison.qmd
@@ -1,0 +1,470 @@
+---
+title: "2025 vs 2026 Performance Comparison"
+format:
+  html:
+    toc: true
+    toc-depth: 3
+    code-fold: true
+execute:
+  warning: false
+  message: false
+project:
+  execute-dir: project
+---
+
+## Introduction
+
+This chapter compares the in-sample performance metrics between the 2025 and 2026 trigger models.
+
+::: {.callout-note}
+## Why In-Sample Comparison?
+
+Both models use different validation approaches:
+
+- **2025**: In-sample evaluation (weights selected from grid search)
+- **2026**: LOOCV re-estimates weights and threshold each fold
+
+These LOOCV approaches test different things and aren't directly comparable. For a fair comparison, we use **in-sample metrics for both**.
+:::
+
+| Aspect | 2025 | 2026 |
+|--------|------|------|
+| Approach | Weight grid search | Ridge regression |
+| Spatial unit | Per province (3 models) | Merged 5-province area (1 model) |
+| Weight selection | Best F1 from ~200k combinations | Regularized coefficients |
+
+```{r}
+#| label: setup
+
+box::use(
+    dplyr[...],
+    tidyr[...],
+    ggplot2[...],
+    gghdx[...],
+    cumulus[...],
+    purrr[...],
+    tibble[tibble]
+)
+
+gghdx()
+```
+
+## 2025 Model: Weight Set 11209
+
+### Load Data
+
+The 2025 model used weight set 11209, selected from an exhaustive grid search.
+
+```{r}
+#| label: load-2025-data
+
+# Load the 2025 weight set time series
+df_2025 <- blob_read(
+    name = "ds-aa-afg-drought/trigger_timeseries/cdi_wt_id_11209.parquet",
+    container = "projects"
+)
+```
+
+### Calculate F1 by Province
+
+```{r}
+#| label: calc-2025-f1
+
+# Calculate F1 per province
+# zscore_flag = CDI exceeds threshold (predicted drought)
+# zscore_asi_Jun_flag = ASI exceeds threshold (actual drought)
+
+df_2025_metrics <- df_2025 |>
+    group_by(adm1_name) |>
+    summarise(
+        n_years = n(),
+        tp = sum(zscore_flag & zscore_asi_Jun_flag, na.rm = TRUE),
+        fp = sum(zscore_flag & !zscore_asi_Jun_flag, na.rm = TRUE),
+        fn = sum(!zscore_flag & zscore_asi_Jun_flag, na.rm = TRUE),
+        tn = sum(!zscore_flag & !zscore_asi_Jun_flag, na.rm = TRUE),
+        .groups = "drop"
+    ) |>
+    mutate(
+        precision = tp / (tp + fp),
+        recall = tp / (tp + fn),
+        f1 = 2 * tp / (2 * tp + fp + fn)
+    )
+
+df_2025_metrics |>
+    select(adm1_name, n_years, tp, fp, fn, precision, recall, f1) |>
+    knitr::kable(
+        digits = 3,
+        caption = "2025 Model: In-Sample Performance by Province (Weight Set 11209)",
+        col.names = c("Province", "N Years", "TP", "FP", "FN", "Precision", "Recall", "F1")
+    )
+```
+
+### Average Performance
+
+```{r}
+#| label: calc-2025-average
+
+df_2025_avg <- df_2025_metrics |>
+    summarise(
+        across(c(precision, recall, f1), mean, na.rm = TRUE)
+    ) |>
+    mutate(model = "2025 (avg over provinces)")
+
+df_2025_avg |>
+    select(precision, recall, f1) |>
+    knitr::kable(
+        digits = 3,
+        caption = "2025 Model: Average In-Sample Performance"
+    )
+```
+
+## 2026 Model: Ridge-Based CDI
+
+The 2026 model uses ridge regression on a merged 5-province area. In-sample metrics from Chapter 12:
+
+```{r}
+#| label: 2026-metrics
+
+df_2026 <- tibble(
+    model = "2026 (merged region)",
+    precision = 0.818,
+    recall = 0.900,
+    f1 = 0.857
+)
+
+df_2026 |>
+    select(precision, recall, f1) |>
+    knitr::kable(
+        digits = 3,
+        caption = "2026 Model: In-Sample Performance"
+    )
+```
+
+## Historical Record Heatmaps
+
+To visualize how each model performs year-by-year, we create heatmaps showing predicted vs actual drought outcomes.
+
+```{r}
+#| label: load-2026-data
+
+# Load 2026 feature set and compute CDI predictions
+df_2026_raw <- blob_read(
+    name = "ds-aa-afg-drought/processed/vector/2026_april_pub_feature_set_v1.parquet",
+    container = "projects"
+)
+
+# CDI weights from Chapter 12 (ridge regression)
+# vhi: ~29%, mixed_fcast_obsv: ~24%, snow_cover: ~19%, asi: ~16%, soil_water: ~12%
+CDI_THRESHOLD <- 0.503  # F1-optimized threshold from Chapter 12
+
+# Calculate CDI for 2026 model
+df_2026_preds <- df_2026_raw |>
+    filter(!is.na(outcome_asi_zscore)) |>
+    mutate(
+        # Calculate CDI as weighted sum
+        CDI = vhi * 0.291 + mixed_fcast_obsv * 0.243 + snow_cover * 0.188 +
+              asi * 0.156 + volumetric_soil_water_1m * 0.122,
+        year = pub_year
+    ) |>
+    # Calculate empirical RP for outcome (ASI) - defines "actual" drought
+    arrange(desc(outcome_asi_zscore)) |>
+    mutate(
+        rank_asi = row_number(),
+        rp_asi = (n() + 1) / rank_asi,
+        actual = rp_asi >= 4  # ASI RP >= 4 = drought year
+    ) |>
+    # Prediction based on CDI threshold (not RP)
+    mutate(
+        predicted = CDI >= CDI_THRESHOLD  # F1-optimized threshold from Ch 12
+    ) |>
+    select(year, CDI, outcome_asi_zscore, predicted, actual) |>
+    arrange(year)
+```
+
+```{r}
+#| label: heatmap-data-prep
+
+# Prepare 2025 data for heatmap
+df_2025_heatmap <- df_2025 |>
+    mutate(
+        year = as.numeric(format(as.Date(yr_season), "%Y")),
+        predicted = zscore_flag,
+        actual = zscore_asi_Jun_flag,
+        outcome = case_when(
+            predicted & actual ~ "TP",
+            predicted & !actual ~ "FP",
+            !predicted & actual ~ "FN",
+            TRUE ~ "TN"
+        )
+    ) |>
+    select(year, adm1_name, predicted, actual, outcome)
+
+# Prepare 2026 data for heatmap
+df_2026_heatmap <- df_2026_preds |>
+    mutate(
+        adm1_name = "Merged Region",
+        outcome = case_when(
+            predicted & actual ~ "TP",
+            predicted & !actual ~ "FP",
+            !predicted & actual ~ "FN",
+            TRUE ~ "TN"
+        )
+    ) |>
+    select(year, adm1_name, predicted, actual, outcome)
+```
+
+### 2025 Model: By Province
+
+```{r}
+#| label: heatmap-2025
+#| fig-height: 4
+#| fig-width: 12
+
+outcome_colors <- c(
+    "TP" = "#2E7D32",  # Green - correct positive
+    "TN" = "#E0E0E0",  # Light gray - correct negative
+    "FP" = "#F57C00",  # Orange - false alarm
+    "FN" = "#C62828"   # Red - missed
+)
+
+df_2025_heatmap |>
+    mutate(
+        outcome = factor(outcome, levels = c("TP", "FP", "FN", "TN")),
+        adm1_name = factor(adm1_name, levels = c("Faryab", "Sar-e-Pul", "Takhar"))
+    ) |>
+    ggplot(aes(x = year, y = adm1_name, fill = outcome)) +
+    geom_tile(color = "white", linewidth = 0.5) +
+    scale_fill_manual(
+        values = outcome_colors,
+        labels = c("TP" = "True Positive", "TN" = "True Negative",
+                   "FP" = "False Positive", "FN" = "False Negative")
+    ) +
+    scale_x_continuous(breaks = seq(1985, 2025, by = 5)) +
+    labs(
+        title = "2025 Model: Historical Predictions by Province",
+        subtitle = "Weight Set 11209",
+        x = "Year",
+        y = NULL,
+        fill = "Outcome"
+    ) +
+    theme(
+        legend.position = "bottom",
+        panel.grid = element_blank()
+    )
+```
+
+### 2026 Model: Merged Region
+
+```{r}
+#| label: heatmap-2026
+#| fig-height: 2.5
+#| fig-width: 12
+
+df_2026_heatmap |>
+    mutate(outcome = factor(outcome, levels = c("TP", "FP", "FN", "TN"))) |>
+    ggplot(aes(x = year, y = adm1_name, fill = outcome)) +
+    geom_tile(color = "white", linewidth = 0.5) +
+    scale_fill_manual(
+        values = outcome_colors,
+        labels = c("TP" = "True Positive", "TN" = "True Negative",
+                   "FP" = "False Positive", "FN" = "False Negative")
+    ) +
+    scale_x_continuous(breaks = seq(1985, 2025, by = 5)) +
+    labs(
+        title = "2026 Model: Historical Predictions",
+        subtitle = "Ridge-based CDI (Merged 5-Province Region)",
+        x = "Year",
+        y = NULL,
+        fill = "Outcome"
+    ) +
+    theme(
+        legend.position = "bottom",
+        panel.grid = element_blank()
+    )
+```
+
+### Combined View
+
+```{r}
+#| label: heatmap-combined
+#| fig-height: 6
+#| fig-width: 12
+
+# Combine both datasets
+df_combined_heatmap <- bind_rows(
+    df_2025_heatmap |> mutate(model = "2025"),
+    df_2026_heatmap |> mutate(model = "2026")
+) |>
+    mutate(
+        panel = paste0(model, ": ", adm1_name),
+        panel = factor(panel, levels = c(
+            "2025: Faryab", "2025: Sar-e-Pul", "2025: Takhar",
+            "2026: Merged Region"
+        )),
+        outcome = factor(outcome, levels = c("TP", "FP", "FN", "TN"))
+    )
+
+df_combined_heatmap |>
+    ggplot(aes(x = year, y = panel, fill = outcome)) +
+    geom_tile(color = "white", linewidth = 0.5) +
+    scale_fill_manual(
+        values = outcome_colors,
+        labels = c("TP" = "True Positive", "TN" = "True Negative",
+                   "FP" = "False Positive", "FN" = "False Negative")
+    ) +
+    scale_x_continuous(breaks = seq(1985, 2025, by = 5)) +
+    labs(
+        title = "Historical Predictions: 2025 vs 2026 Models",
+        x = "Year",
+        y = NULL,
+        fill = "Outcome"
+    ) +
+    theme(
+        legend.position = "bottom",
+        panel.grid = element_blank(),
+        axis.text.y = element_text(size = 10)
+    )
+```
+
+### Years Where Models Differ
+
+```{r}
+#| label: model-differences
+
+# Compare 2025 (majority vote across provinces) with 2026
+df_2025_majority <- df_2025_heatmap |>
+    group_by(year) |>
+    summarise(
+        predicted_2025 = sum(predicted) >= 2,  # majority vote
+        actual_2025 = sum(actual) >= 2,
+        .groups = "drop"
+    )
+
+df_comparison_years <- df_2025_majority |>
+    inner_join(
+        df_2026_heatmap |> select(year, predicted_2026 = predicted, actual_2026 = actual),
+        by = "year"
+    ) |>
+    mutate(
+        models_agree = predicted_2025 == predicted_2026,
+        outcome_2025 = case_when(
+            predicted_2025 & actual_2025 ~ "TP",
+            predicted_2025 & !actual_2025 ~ "FP",
+            !predicted_2025 & actual_2025 ~ "FN",
+            TRUE ~ "TN"
+        ),
+        outcome_2026 = case_when(
+            predicted_2026 & actual_2026 ~ "TP",
+            predicted_2026 & !actual_2026 ~ "FP",
+            !predicted_2026 & actual_2026 ~ "FN",
+            TRUE ~ "TN"
+        )
+    )
+
+# Show years where models disagree
+df_comparison_years |>
+    filter(!models_agree) |>
+    select(year, outcome_2025, outcome_2026) |>
+    knitr::kable(
+        caption = "Years Where 2025 (Majority Vote) and 2026 Models Disagree",
+        col.names = c("Year", "2025 Outcome", "2026 Outcome")
+    )
+```
+
+## Side-by-Side Comparison
+
+```{r}
+#| label: comparison-table
+
+df_comparison <- bind_rows(
+    df_2025_metrics |>
+        select(precision, recall, f1) |>
+        mutate(model = paste0("2025 ", df_2025_metrics$adm1_name)),
+    df_2025_avg |> select(model, precision, recall, f1),
+    df_2026
+) |>
+    select(model, precision, recall, f1)
+
+df_comparison |>
+    knitr::kable(
+        digits = 3,
+        caption = "In-Sample Performance Comparison: 2025 vs 2026",
+        col.names = c("Model", "Precision", "Recall", "F1")
+    )
+```
+
+```{r}
+#| label: comparison-plot
+#| fig-height: 5
+#| fig-width: 8
+
+df_comparison |>
+    mutate(
+        model = factor(model, levels = rev(model)),
+        model_type = case_when(
+            grepl("2025", model) & !grepl("avg", model) ~ "2025 (by province)",
+            grepl("2025", model) ~ "2025 (average)",
+            TRUE ~ "2026"
+        )
+    ) |>
+    ggplot(aes(x = f1, y = model, fill = model_type)) +
+    geom_col(width = 0.7) +
+    geom_text(aes(label = round(f1, 3)), hjust = -0.1, size = 3.5) +
+    scale_x_continuous(limits = c(0, 1), expand = c(0, 0.05)) +
+    scale_fill_manual(values = c(
+        "2025 (by province)" = "steelblue",
+        "2025 (average)" = "darkblue",
+        "2026" = "tomato"
+    )) +
+    labs(
+        title = "In-Sample F1 Score Comparison: 2025 vs 2026",
+        x = "F1 Score",
+        y = NULL,
+        fill = "Model"
+    ) +
+    theme(legend.position = "bottom")
+```
+
+## Summary
+
+```{r}
+#| label: summary-table
+
+tibble(
+    Metric = c("F1 Score", "Precision", "Recall", "Spatial Unit", "N Years"),
+    `2025 Model` = c(
+        round(df_2025_avg$f1, 3),
+        round(df_2025_avg$precision, 3),
+        round(df_2025_avg$recall, 3),
+        "Per province (avg of 3)",
+        "41 per province"
+    ),
+    `2026 Model` = c(
+        "0.857",
+        "0.818",
+        "0.900",
+        "Merged 5-province",
+        "42"
+    )
+) |>
+    knitr::kable(caption = "Summary: In-Sample Performance Comparison")
+```
+
+::: {.callout-important}
+## Key Findings
+
+**In-sample comparison** (both models evaluated on training data):
+
+| Model | F1 | Precision | Recall |
+|-------|-----|-----------|--------|
+| 2025 (avg) | **0.833** | 0.833 | 0.833 |
+| 2026 | **0.857** | 0.818 | 0.900 |
+
+The 2026 model shows slightly higher F1 (0.857 vs 0.833) with notably higher recall (0.900 vs 0.833).
+
+**Caveats:**
+
+1. **Spatial units differ**: 2025 averages 3 provinces; 2026 models merged 5-province area
+2. **Both are in-sample**: These metrics are optimistic; true out-of-sample performance would be lower
+3. **2026 LOOCV F1 = 0.762**: The only honest out-of-sample estimate available
+:::

--- a/book_afg_analysis/_publish.yml
+++ b/book_afg_analysis/_publish.yml
@@ -1,7 +1,7 @@
 - source: project
   quarto-pub:
     - id: a2b414ee-6fbc-4dc8-a07e-74009b9882c6
-      url: 'https://zackarno.quarto.pub/anticipatory-action---drought-afghanistan---2025'
+      url: https://zackarno.quarto.pub/anticipatory-action---drought-afghanistan---2025
   netlify:
     - id: 68eb38e8-cfcd-4585-9ed7-5ccb150685da
-      url: 'https://drought-aa-afghanistan.netlify.app'
+      url: https://drought-aa-afghanistan.netlify.app

--- a/book_afg_analysis/_quarto.yml
+++ b/book_afg_analysis/_quarto.yml
@@ -1,7 +1,7 @@
 project:
   type: book
 
-jupyter: dsci_playground
+jupyter: ds-aa-afg-drought
 
 book:
   title: "Anticipatory Action - Drought Afghanistan - 2025"
@@ -19,6 +19,8 @@ book:
     - 08_weight_selection.qmd
     - 09_pre_season_allocation_options.qmd
     - 12_2026_trigger_modeling.qmd
+    - 13_2026_trigger_proposal.qmd
+    - 14_cerf_allocation_alignment.qmd
     - summary.qmd
     - references.qmd
   appendices:

--- a/book_afg_analysis/_quarto.yml
+++ b/book_afg_analysis/_quarto.yml
@@ -9,6 +9,7 @@ book:
   date: "12/10/2024"
   chapters:
     - index.qmd
+    - 00_key_findings.qmd
     - intro.qmd
     - 02_prioritization_rainfall.qmd
     - 03_initial_proposal_faryab.qmd
@@ -26,6 +27,8 @@ book:
   appendices:
     - 10_asi_provincial_correlation.qmd
     - 11_multi_year_drought.qmd
+    - 15_baseline_sensitivity.qmd
+    - 16_performance_comparison.qmd
 
 bibliography: references.bib
 

--- a/exploration/compare_seas5_r_python.qmd
+++ b/exploration/compare_seas5_r_python.qmd
@@ -1,0 +1,255 @@
+---
+title: "SEAS5 MAM Aggregation: R vs Python Comparison"
+format: html
+---
+
+Verify that the Python monitoring pipeline (`w1_monitor_seas5.py`) produces
+identical regional MAM aggregates to the R pipeline used for threshold
+derivation (`data-raw/16_prepare_2026_model_feature_datasets.R`).
+
+## Setup
+
+```{r}
+#| label: setup-r
+library(dplyr)
+library(lubridate)
+library(cumulus)
+library(reticulate)
+library(ggplot2)
+# Point reticulate at the uv-managed venv
+use_virtualenv(here::here(".venv"), required = TRUE)
+```
+
+```{python}
+#| label: setup-python
+import sys
+from pathlib import Path
+
+# ensure project root is on path for imports
+sys.path.insert(0, str(Path.cwd()))
+
+from calendar import monthrange
+
+import numpy as np
+import ocha_stratus as stratus
+import pandas as pd
+from sqlalchemy import text
+```
+
+## Constants
+
+```{r}
+#| label: constants
+PROVINCES_AOI <- c("Faryab", "Sar-e-Pul", "Jawzjan", "Balkh", "Badghis")
+```
+
+## R Pipeline
+
+Replicate the exact logic from `data-raw/16_prepare_2026_model_feature_datasets.R`:
+
+1. Load SEAS5 from DB with `cumulus::pg_load_seas5_historical()` (which applies `mean * days_in_month`)
+2. Aggregate MAM months with `cumulus::seas5_aggregate_forecast()`
+3. Join area weights from ERA5 blob
+4. Compute `weighted.mean()` across provinces
+
+```{r}
+#| label: r-seas5-load
+# Load SEAS5 with unit conversion (daily rate -> monthly mm)
+df_seas5 <- pg_load_seas5_historical(
+  iso3 = "AFG",
+  adm_name = PROVINCES_AOI,
+  adm_level = 1,
+  convert_units = TRUE
+)
+
+# Aggregate to MAM total per province per issued_date (March only)
+df_seas5_mam <- seas5_aggregate_forecast(
+  df = df_seas5,
+  value = "mean",
+  valid_months = c(3, 4, 5),
+  by = c("iso3", "pcode", "name", "issued_date")
+) |>
+  filter(month(issued_date) == 3) |>
+  rename(adm1_name = name, mam_mm = mean)
+
+glimpse(df_seas5_mam)
+```
+
+```{r}
+#| label: r-area-weights
+# Load area weights from ERA5 blob (same source as Python pipeline)
+df_era5 <- blob_read(
+  name = "ds-aa-afg-drought/raw/vector/historical_era5_land_ndjfmam_lte2025.parquet",
+  stage = "dev",
+  container_name = "projects"
+) |>
+  janitor::clean_names()
+
+df_area_lookup <- df_era5 |>
+  filter(adm1_name %in% PROVINCES_AOI) |>
+  distinct(adm1_name, shape_area)
+
+df_area_lookup
+```
+
+```{r}
+#| label: r-regional-aggregate
+# Area-weighted regional mean per year
+df_r_regional <- df_seas5_mam |>
+  left_join(df_area_lookup, by = "adm1_name") |>
+  group_by(issued_date) |>
+  summarise(
+    r_mam_mm = weighted.mean(mam_mm, w = shape_area, na.rm = TRUE),
+    .groups = "drop"
+  ) |>
+  mutate(year = year(issued_date)) |>
+  filter(year >= 1984) |>
+  select(year, r_mam_mm) |>
+  arrange(year)
+
+df_r_regional
+```
+
+## Python Pipeline
+
+Same logic as `w1_monitor_seas5.py`:
+
+1. Query SEAS5 from prod DB
+2. `mean * days_in_month` -> monthly mm
+3. Sum MAM per province
+4. `np.average` with `shape_area` weights
+
+```{python}
+#| label: py-load-data
+# Load area weights
+df_areas = stratus.load_parquet_from_blob(
+    blob_name="ds-aa-afg-drought/raw/vector/historical_era5_land_ndjfmam_lte2025.parquet",
+    stage="dev",
+    container_name="projects",
+)
+
+df_areas.columns = df_areas.columns.str.lower().str.replace(" ", "_")
+df_areas = df_areas.loc[df_areas["adm1_name"].isin(
+    ["Faryab", "Sar-e-Pul", "Jawzjan", "Balkh", "Badghis"]
+)][["adm1_name", "shape_area"]].drop_duplicates()
+
+# Load admin lookup
+df_lookup = stratus.load_parquet_from_blob(
+    blob_name="admin_lookup.parquet",
+    stage="dev",
+    container_name="polygon",
+)
+df_lookup.columns = df_lookup.columns.str.lower()
+df_lookup = df_lookup.loc[
+    (df_lookup["iso3"] == "AFG")
+    & (df_lookup["adm_level"] == 1)
+    & (df_lookup["adm1_name"].isin(
+        ["Faryab", "Sar-e-Pul", "Jawzjan", "Balkh", "Badghis"]
+    )),
+    ["adm1_name", "adm1_pcode"],
+].drop_duplicates()
+pcodes = df_lookup["adm1_pcode"].tolist()
+print(f"Pcodes: {pcodes}")
+print(f"Area weights:\n{df_areas}")
+```
+
+```{python}
+#| label: py-query-aggregate
+# Query SEAS5 from prod
+engine = stratus.get_engine(stage="prod")
+pcode_list = ", ".join(f"'{p}'" for p in pcodes)
+sql = text(f"""
+    SELECT iso3, pcode, valid_date, issued_date, leadtime, mean
+    FROM seas5
+    WHERE iso3 = 'AFG'
+      AND adm_level = 1
+      AND pcode IN ({pcode_list})
+      AND EXTRACT(MONTH FROM issued_date) = 3
+      AND EXTRACT(MONTH FROM valid_date) IN (3, 4, 5)
+    ORDER BY issued_date, pcode, valid_date
+""")
+with engine.connect() as conn:
+    df = pd.read_sql(sql, conn)
+
+# daily rate -> monthly mm
+df["days"] = df["valid_date"].apply(lambda d: monthrange(d.year, d.month)[1])
+df["precip_mm"] = df["mean"] * df["days"]
+
+# MAM sum per province
+df_province = (
+    df.groupby(["issued_date", "pcode"], as_index=False)["precip_mm"]
+    .sum()
+    .rename(columns={"precip_mm": "mam_mm"})
+)
+df_province = df_province.merge(
+    df_lookup.rename(columns={"adm1_pcode": "pcode"}), on="pcode", how="left"
+)
+
+# area-weighted regional mean
+df_province = df_province.merge(df_areas, on="adm1_name", how="left")
+
+def _weighted_mean(g):
+    return np.average(g["mam_mm"], weights=g["shape_area"])
+
+df_py_regional = (
+    df_province.groupby("issued_date", as_index=False)
+    .apply(_weighted_mean, include_groups=False)
+    .rename(columns={None: "py_mam_mm"})
+)
+df_py_regional["year"] = pd.to_datetime(df_py_regional["issued_date"]).dt.year
+df_py_regional = (
+    df_py_regional.loc[df_py_regional["year"] >= 1984][["year", "py_mam_mm"]]
+    .sort_values("year")
+    .reset_index(drop=True)
+)
+print(df_py_regional)
+```
+
+## Comparison
+
+```{r}
+#| label: compare
+# Pull Python results into R via reticulate
+df_py <- py$df_py_regional
+
+# Merge
+df_compare <- df_r_regional |>
+  inner_join(df_py, by = "year") |>
+  mutate(
+    diff_mm = r_mam_mm - py_mam_mm,
+    diff_pct = diff_mm / r_mam_mm * 100
+  )
+
+cat("Max absolute difference (mm):", max(abs(df_compare$diff_mm)), "\n")
+cat("Max relative difference (%):", max(abs(df_compare$diff_pct)), "\n")
+cat("Number of years compared:", nrow(df_compare), "\n")
+```
+
+```{r}
+#| label: compare-table
+df_compare |>
+  select(year, r_mam_mm, py_mam_mm, diff_mm) |>
+  mutate(across(where(is.numeric) & !matches("year"), ~round(.x, 4))) |>
+  knitr::kable(
+    col.names = c("Year", "R (mm)", "Python (mm)", "Diff (mm)"),
+    caption = "SEAS5 MAM regional aggregate: R vs Python"
+  )
+```
+
+```{r}
+#| label: compare-plot
+#| fig-width: 8
+#| fig-height: 4
+
+
+ggplot(df_compare, aes(x = r_mam_mm, y = py_mam_mm)) +
+  geom_abline(slope = 1, intercept = 0, linetype = "dashed", color = "grey50") +
+  geom_point(alpha = 0.7) +
+  labs(
+    x = "R pipeline (mm)",
+    y = "Python pipeline (mm)",
+    title = "SEAS5 MAM Regional Aggregate: R vs Python",
+    subtitle = "Points on the dashed line = perfect agreement"
+  ) +
+  theme_minimal()
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "nbformat>=5.10.0",
     "pyyaml>=6.0",
     "nbclient>=0.10.0",
+    "requests>=2.31",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "ipykernel>=7.1.0",
     "earthengine-api>=1.7.4",
     "geemap>=0.36.6",
+    "nbformat>=5.10.0",
+    "pyyaml>=6.0",
+    "nbclient>=0.10.0",
 ]
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 cfgrib==0.9.12.0
-e==1.4.5
 eccodes==1.7.0
 ecmwf-api-client==1.6.3
 findlibs==0.0.5

--- a/src/monitoring_2026/listmonk.py
+++ b/src/monitoring_2026/listmonk.py
@@ -7,6 +7,7 @@ BASE_URL = (
 )
 
 BASE_CAMPAIGN_ID = 8
+BASE_TRANSACTIONAL_ID = 12
 
 USERNAME = os.getenv("DSCI_LISTMONK_API_USERNAME")
 PASSWORD = os.getenv("DSCI_LISTMONK_API_KEY")
@@ -50,3 +51,45 @@ def send_campaign(campaign_id: int):
         json={"status": "running"},
     )
     r.raise_for_status()
+
+
+def send_transactional(
+    to_emails: list[tuple[str, str]],
+    subject: str,
+    template_id: int = BASE_TRANSACTIONAL_ID,
+    cc_emails: list[tuple[str, str]] = None,
+    data: dict = None,
+):
+    payload = {
+        "subscriber_email": to_emails[0][1],
+        "template_id": template_id,
+        "from_email": "OCHA Data Science <ocha-datascience@un.org>",
+        "content_type": "html",
+        "subject": subject,
+        "data": data or {},
+        "headers": [
+            {
+                "To": ", ".join(
+                    [f"{name} <{email}>" for name, email in to_emails]
+                )
+            },
+            {
+                "Cc": ", ".join(
+                    [f"{name} <{email}>" for name, email in cc_emails or []]
+                )
+            },
+        ],
+    }
+
+    r = requests.post(
+        f"{BASE_URL}/tx",
+        auth=(USERNAME, PASSWORD),
+        json=payload,
+    )
+    if not r.ok:
+        print("Status:", r.status_code)
+        print("Response text:", r.text)
+        print("Payload sent:", payload)
+
+    r.raise_for_status()
+    return r.json()

--- a/src/monitoring_2026/listmonk.py
+++ b/src/monitoring_2026/listmonk.py
@@ -1,0 +1,52 @@
+import os
+
+import requests
+
+BASE_URL = (
+    "https://listmonk-demo-afhcg8e2hde0fxca.eastus2-01.azurewebsites.net/api"  # noqa
+)
+
+BASE_CAMPAIGN_ID = 8
+
+USERNAME = os.getenv("DSCI_LISTMONK_API_USERNAME")
+PASSWORD = os.getenv("DSCI_LISTMONK_API_KEY")
+
+
+def create_campaign(
+    name: str = "test_campaign",
+    subject: str = "Test Subject",
+    list_ids: list[int] = None,
+    template_id: int = BASE_CAMPAIGN_ID,
+    body: str = "TEST CONTENT",
+):
+    if list_ids is None:
+        list_ids = []
+    create_payload = {
+        "name": name,
+        "subject": subject,
+        "lists": list_ids,
+        "template_id": template_id,
+        "type": "regular",
+        "content_type": "html",
+        "body": body,
+    }
+
+    r = requests.post(
+        f"{BASE_URL}/campaigns",
+        auth=(USERNAME, PASSWORD),
+        json=create_payload,
+    )
+
+    r.raise_for_status()
+    campaign = r.json()["data"]
+    campaign_id = campaign["id"]
+    return campaign_id
+
+
+def send_campaign(campaign_id: int):
+    r = requests.put(
+        f"{BASE_URL}/campaigns/{campaign_id}/status",
+        auth=(USERNAME, PASSWORD),
+        json={"status": "running"},
+    )
+    r.raise_for_status()

--- a/src/monitoring_2026/w1_monitor_seas5.py
+++ b/src/monitoring_2026/w1_monitor_seas5.py
@@ -348,8 +348,8 @@ for drought in Afghanistan, Window 1 evaluates the SEAS5 seasonal
 precipitation forecast issued in March for the
 March&ndash;April&ndash;May season. An area-weighted regional aggregate
 across the five target provinces is compared against a return-period 6
-threshold. If the forecast falls at or below the threshold, the trigger
-is activated.
+threshold. If the forecast falls at or below the threshold, the
+threshold is considered reached.
 </p>
 """
 

--- a/src/monitoring_2026/w1_monitor_seas5.py
+++ b/src/monitoring_2026/w1_monitor_seas5.py
@@ -39,7 +39,7 @@ AREA_BLOB = (
     "ds-aa-afg-drought/raw/vector/historical_era5_land_ndjfmam_lte2025.parquet"
 )
 ADMIN_LOOKUP_BLOB = "admin_lookup.parquet"
-OUTPUT_BLOB_DIR = "ds-aa-afg-drought/monitoring_outputs/2026"
+OUTPUT_BLOB_BASE = "ds-aa-afg-drought/monitoring_outputs"
 
 
 # ── data loading ─────────────────────────────────────────────────────
@@ -381,27 +381,31 @@ def main(year: int):
     print(f"Regional MAM series: {len(df_regional)} years")
 
     # outputs
+    prefix = f"{year}03"
     out_dir = Path("outputs")
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    plot_path = out_dir / "seas5_w1_monitor.png"
-    summary_path = out_dir / "seas5_w1_summary.json"
+    plot_name = f"{prefix}_seas5_w1_monitor.png"
+    summary_name = f"{prefix}_seas5_w1_summary.json"
+    plot_path = out_dir / plot_name
+    summary_path = out_dir / summary_name
 
     make_plot(df_regional, year, threshold_mm, plot_path)
     summary = write_summary(df_regional, year, threshold_mm, summary_path)
 
     # upload to blob
-    print("Uploading outputs to blob...")
+    blob_dir = f"{OUTPUT_BLOB_BASE}/{year}"
+    print(f"Uploading outputs to blob: {blob_dir}/...")
     stratus.upload_blob_data(
         data=plot_path.read_bytes(),
-        blob_name=f"{OUTPUT_BLOB_DIR}/seas5_w1_monitor.png",
+        blob_name=f"{blob_dir}/{plot_name}",
         stage="dev",
         container_name="projects",
         content_type="image/png",
     )
     stratus.upload_blob_data(
         data=json.dumps(summary, indent=2).encode(),
-        blob_name=f"{OUTPUT_BLOB_DIR}/seas5_w1_summary.json",
+        blob_name=f"{blob_dir}/{summary_name}",
         stage="dev",
         container_name="projects",
         content_type="application/json",

--- a/src/monitoring_2026/w1_monitor_seas5.py
+++ b/src/monitoring_2026/w1_monitor_seas5.py
@@ -14,6 +14,7 @@ Outputs (uploaded to blob):
 """
 
 import argparse
+import base64
 import json
 from calendar import monthrange
 from datetime import UTC, datetime
@@ -23,6 +24,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import ocha_stratus as stratus
 import pandas as pd
+from listmonk import create_campaign, send_campaign
 from sqlalchemy import text
 
 # ── constants ────────────────────────────────────────────────────────
@@ -282,6 +284,76 @@ def write_summary(df_regional, current_year, threshold_mm, output_path):
     return summary
 
 
+# ── email ─────────────────────────────────────────────────────────────
+TEST_LIST_ID = 16  # TODO: replace with Listmonk list ID
+PROD_LIST_ID = "placeholder"  # TODO: replace with Listmonk list ID
+
+
+def build_email_html(summary: dict, plot_path: Path) -> str:
+    """Build HTML email body with trigger results and inline chart."""
+    triggered = summary["triggered"]
+    status = "ACTIVATED" if triggered else "NOT ACTIVATED"
+    forecast_mm = summary["forecast_mam_mm"]
+    threshold_mm = summary["threshold_mm"]
+    status_color = "#F2645A" if triggered else "#1EBFB3"
+
+    plot_b64 = base64.b64encode(plot_path.read_bytes()).decode()
+
+    return f"""
+Dear colleagues,
+<br><br>
+This is an automated monitoring update for the
+<b>Anticipatory Action framework for drought in Afghanistan</b>,
+Window 1 (SEAS5 seasonal precipitation forecast).
+<br><br>
+<table style="border-collapse:collapse;width:100%;" cellpadding="0"
+ cellspacing="0">
+<tr><td style="padding:12px 16px;background-color:{status_color};
+color:#FFFFFF;font-size:18px;font-weight:bold;text-align:center;">
+Window 1 SEAS5 trigger: {status}</td></tr>
+</table>
+<br>
+<table style="border-collapse:collapse;" cellpadding="8" cellspacing="0">
+<tr>
+  <td style="border:1px solid #DDD;font-weight:bold;">
+  SEAS5 MAM forecast</td>
+  <td style="border:1px solid #DDD;">{forecast_mm:.1f} mm</td>
+</tr>
+<tr>
+  <td style="border:1px solid #DDD;font-weight:bold;">
+  RP6 threshold</td>
+  <td style="border:1px solid #DDD;">{threshold_mm:.1f} mm</td>
+</tr>
+<tr>
+  <td style="border:1px solid #DDD;font-weight:bold;">
+  Trigger direction</td>
+  <td style="border:1px solid #DDD;">
+  Forecast &le; threshold (low precipitation indicates drought risk)
+  </td>
+</tr>
+</table>
+<br>
+The chart below shows the historical and current SEAS5
+March&ndash;April&ndash;May (MAM) precipitation forecast for the five
+northern Afghan provinces (Badghis, Balkh, Faryab, Jawzjan, Sar-e-Pul),
+compared against the return-period 6 threshold.
+<br><br>
+<img src="data:image/png;base64,{plot_b64}"
+ alt="SEAS5 MAM forecast bar chart"
+ style="max-width:100%;height:auto;" />
+<br><br>
+<p style="font-size:12px;color:#666;">
+<b>About the framework:</b> Under the anticipatory action framework
+for drought in Afghanistan, Window 1 evaluates the SEAS5 seasonal
+precipitation forecast issued in March for the
+March&ndash;April&ndash;May season. An area-weighted regional aggregate
+across the five target provinces is compared against a return-period 6
+threshold. If the forecast falls at or below the threshold, the trigger
+is activated.
+</p>
+"""
+
+
 # ── main ─────────────────────────────────────────────────────────────
 def main(year: int):
     print(f"SEAS5 Window 1 monitoring for {year}")
@@ -335,6 +407,27 @@ def main(year: int):
         content_type="application/json",
     )
     print("Upload complete.")
+
+    # email notification
+    triggered = summary["triggered"]
+    status = "ACTIVATED" if triggered else "NOT ACTIVATED"
+    year = summary["issued_year"]
+
+    body_html = build_email_html(summary, plot_path)
+    subject = (
+        "Anticipatory action Afghanistan: "
+        f"Drought W1 SEAS5 forecast [{status}]"
+    )
+
+    campaign_id = create_campaign(
+        name=f"[test] seas5_w1_{year}",
+        subject=subject,
+        list_ids=[TEST_LIST_ID],
+        body=body_html,
+    )
+    print(f"Created campaign with ID: {campaign_id}")
+    send_campaign(campaign_id)
+    print("Campaign sent.")
 
     return summary
 

--- a/src/monitoring_2026/w1_monitor_seas5.py
+++ b/src/monitoring_2026/w1_monitor_seas5.py
@@ -30,7 +30,7 @@ from sqlalchemy import text
 # ── constants ────────────────────────────────────────────────────────
 PROVINCES_AOI = ["Faryab", "Sar-e-Pul", "Jawzjan", "Balkh", "Badghis"]
 VALID_MONTHS = [3, 4, 5]
-BASELINE_START_YEAR = 1984
+BASELINE_START_YEAR = 1991
 
 THRESHOLD_BLOB = (
     "ds-aa-afg-drought/monitoring_inputs/2026/trigger_thresholds.parquet"

--- a/src/monitoring_2026/w1_monitor_seas5.py
+++ b/src/monitoring_2026/w1_monitor_seas5.py
@@ -1,0 +1,353 @@
+"""
+Window 1 (March) SEAS5 forecast monitoring for 2026 drought trigger.
+
+Queries SEAS5 MAM seasonal forecast from the prod postgres database,
+computes the area-weighted regional aggregate for 5 northern Afghan
+provinces, and compares against the RP6 threshold.
+
+The threshold parquet is read from blob:
+    ds-aa-afg-drought/monitoring_inputs/2026/trigger_thresholds.parquet
+
+Outputs (uploaded to blob):
+    - Plot: .../monitoring_outputs/2026/seas5_w1_monitor.png
+    - Summary: .../monitoring_outputs/2026/seas5_w1_summary.json
+"""
+
+import argparse
+import json
+from calendar import monthrange
+from datetime import UTC, datetime
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import ocha_stratus as stratus
+import pandas as pd
+from sqlalchemy import text
+
+# ── constants ────────────────────────────────────────────────────────
+PROVINCES_AOI = ["Faryab", "Sar-e-Pul", "Jawzjan", "Balkh", "Badghis"]
+VALID_MONTHS = [3, 4, 5]
+BASELINE_START_YEAR = 1984
+
+THRESHOLD_BLOB = (
+    "ds-aa-afg-drought/monitoring_inputs/2026/trigger_thresholds.parquet"
+)
+AREA_BLOB = (
+    "ds-aa-afg-drought/raw/vector/historical_era5_land_ndjfmam_lte2025.parquet"
+)
+ADMIN_LOOKUP_BLOB = "admin_lookup.parquet"
+OUTPUT_BLOB_DIR = "ds-aa-afg-drought/monitoring_outputs/2026"
+
+
+# ── data loading ─────────────────────────────────────────────────────
+def load_admin_lookup():
+    """Load admin lookup from blob (replicates cumulus blob_load_admin_lookup).
+
+    Returns a DataFrame filtered to AFG adm1 provinces of interest
+    with columns: adm1_name, adm1_pcode.
+    """
+    df = stratus.load_parquet_from_blob(
+        blob_name=ADMIN_LOOKUP_BLOB,
+        stage="dev",
+        container_name="polygon",
+    )
+    df.columns = df.columns.str.lower()
+    df = df.loc[
+        (df["iso3"] == "AFG")
+        & (df["adm_level"] == 1)
+        & (df["adm1_name"].isin(PROVINCES_AOI)),
+        ["adm1_name", "adm1_pcode"],
+    ].drop_duplicates()
+    return df
+
+
+def load_threshold_mm():
+    """Load the SEAS5 RP6 mm threshold from blob."""
+    df = stratus.load_parquet_from_blob(
+        blob_name=THRESHOLD_BLOB,
+        stage="dev",
+        container_name="projects",
+    )
+    row = df.loc[df["indicator"] == "seas5_mam"].iloc[0]
+    return float(row["threshold_value"])
+
+
+def load_area_weights():
+    """Load province shape areas for regional aggregation."""
+    df = stratus.load_parquet_from_blob(
+        blob_name=AREA_BLOB,
+        stage="dev",
+        container_name="projects",
+    )
+    df.columns = df.columns.str.lower().str.replace(" ", "_")
+    df = df.loc[df["adm1_name"].isin(PROVINCES_AOI)][
+        ["adm1_name", "shape_area"]
+    ].drop_duplicates()
+    return df
+
+
+def query_seas5_mam(engine, pcodes):
+    """
+    Query all March-issued SEAS5 MAM forecasts from prod postgres.
+
+    Parameters
+    ----------
+    engine : sqlalchemy engine
+    pcodes : list of str
+        Admin1 pcodes to filter (e.g. ['AF29', 'AF22', ...]).
+
+    Returns per-province, per-year rows with columns:
+        issued_date, pcode, valid_date, mean, leadtime
+    """
+    pcode_list = ", ".join(f"'{p}'" for p in pcodes)
+    valid_month_list = ", ".join(str(m) for m in VALID_MONTHS)
+
+    sql = text(f"""
+        SELECT iso3, pcode, valid_date, issued_date,
+               leadtime, mean
+        FROM seas5
+        WHERE iso3 = 'AFG'
+          AND adm_level = 1
+          AND pcode IN ({pcode_list})
+          AND EXTRACT(MONTH FROM issued_date) = 3
+          AND EXTRACT(MONTH FROM valid_date) IN ({valid_month_list})
+        ORDER BY issued_date, pcode, valid_date
+    """)
+
+    with engine.connect() as conn:
+        df = pd.read_sql(sql, conn)
+
+    return df
+
+
+# ── aggregation ──────────────────────────────────────────────────────
+def aggregate_regional_mam(df_seas5, df_areas, df_lookup):
+    """
+    Convert daily-rate forecast to MAM total (mm), then compute
+    area-weighted regional mean per issued year.
+
+    Pipeline mirrors the R feature-set creation (data-raw/16_*):
+        1. precipitation = mean × days_in_month  (daily rate → monthly)
+        2. sum across valid months per province   (→ MAM total)
+        3. weighted.mean across provinces         (→ regional)
+    """
+    df = df_seas5.copy()
+
+    # daily rate → monthly total (mm)
+    df["days"] = df["valid_date"].apply(
+        lambda d: monthrange(d.year, d.month)[1]
+    )
+    df["precip_mm"] = df["mean"] * df["days"]
+
+    # sum MAM months per province per issued_date
+    df_province = (
+        df.groupby(["issued_date", "pcode"], as_index=False)["precip_mm"]
+        .sum()
+        .rename(columns={"precip_mm": "mam_mm"})
+    )
+
+    # join pcode → adm1_name via admin lookup
+    df_province = df_province.merge(
+        df_lookup.rename(columns={"adm1_pcode": "pcode"}),
+        on="pcode",
+        how="left",
+    )
+
+    # area-weighted regional mean
+    df_province = df_province.merge(df_areas, on="adm1_name", how="left")
+
+    def _weighted_mean(g):
+        return np.average(g["mam_mm"], weights=g["shape_area"])
+
+    df_regional = (
+        df_province.groupby("issued_date", as_index=False)
+        .apply(_weighted_mean, include_groups=False)
+        .rename(columns={None: "mam_mm"})
+    )
+    df_regional["year"] = pd.to_datetime(df_regional["issued_date"]).dt.year
+
+    return df_regional
+
+
+# ── plotting ─────────────────────────────────────────────────────────
+def make_plot(df_regional, current_year, threshold_mm, output_path):
+    """
+    Bar chart of historical + current year MAM forecast vs RP6
+    threshold. Current year highlighted; bars below threshold in red.
+    """
+    df = df_regional.sort_values("year").copy()
+    df["below"] = df["mam_mm"] <= threshold_mm
+    df["is_current"] = df["year"] == current_year
+
+    fig, ax = plt.subplots(figsize=(12, 5))
+
+    colors = []
+    for _, row in df.iterrows():
+        if row["is_current"]:
+            colors.append("#1EBFB3" if not row["below"] else "#F2645A")
+        elif row["below"]:
+            colors.append("#F2645A66")
+        else:
+            colors.append("#1EBFB366")
+
+    ax.bar(df["year"], df["mam_mm"], color=colors, width=0.8)
+
+    # threshold line
+    ax.axhline(
+        threshold_mm,
+        color="#333333",
+        linestyle="--",
+        linewidth=1.5,
+        label=f"RP6 threshold ({threshold_mm:.0f} mm)",
+    )
+
+    # annotate current year
+    current_row = df.loc[df["year"] == current_year]
+    if not current_row.empty:
+        val = current_row["mam_mm"].iloc[0]
+        triggered = val <= threshold_mm
+        status = "TRIGGERED" if triggered else "Not triggered"
+        color = "#F2645A" if triggered else "#1EBFB3"
+        ax.annotate(
+            f"{current_year}: {val:.0f} mm\n{status}",
+            xy=(current_year, val),
+            xytext=(0, 15),
+            textcoords="offset points",
+            ha="center",
+            fontsize=10,
+            fontweight="bold",
+            color=color,
+            arrowprops=dict(arrowstyle="-", color=color, lw=1.5),
+        )
+
+    ax.set_xlabel("Issued year (March forecast)")
+    ax.set_ylabel("MAM precipitation forecast (mm)")
+    ax.set_title(
+        "SEAS5 MAM Forecast – Regional Aggregate\n"
+        "Afghanistan Northern Provinces Drought Trigger (Window 1)",
+        fontsize=12,
+    )
+    ax.legend(loc="upper right")
+    ax.set_ylim(bottom=0)
+
+    # only label every 5th year to avoid crowding
+    years = df["year"].values
+    ax.set_xticks(years[::5])
+    ax.set_xticklabels(years[::5], rotation=45, ha="right")
+
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Plot saved: {output_path}")
+
+
+# ── summary ──────────────────────────────────────────────────────────
+def write_summary(df_regional, current_year, threshold_mm, output_path):
+    """Write JSON summary with trigger decision."""
+    current = df_regional.loc[df_regional["year"] == current_year]
+    if current.empty:
+        raise ValueError(
+            f"No SEAS5 forecast found for {current_year}. "
+            "Has the March forecast been issued?"
+        )
+
+    forecast_mm = float(current["mam_mm"].iloc[0])
+    triggered = forecast_mm <= threshold_mm
+
+    summary = {
+        "window": "W1_SEAS5",
+        "issued_year": current_year,
+        "issued_month": 3,
+        "forecast_mam_mm": round(forecast_mm, 2),
+        "threshold_mm": round(threshold_mm, 2),
+        "threshold_rp": 6,
+        "triggered": triggered,
+        "direction": "forecast <= threshold",
+        "provinces": PROVINCES_AOI,
+        "generated_utc": datetime.now(UTC).isoformat(timespec="seconds"),
+    }
+
+    output_path.write_text(json.dumps(summary, indent=2))
+    print(f"Summary saved: {output_path}")
+
+    # also print to stdout for GHA logs
+    status = "TRIGGERED" if triggered else "NOT TRIGGERED"
+    print(f"\n{'=' * 50}")
+    print(f"  SEAS5 W1 Result: {status}")
+    print(f"  Forecast: {forecast_mm:.1f} mm")
+    print(f"  Threshold (RP6): {threshold_mm:.1f} mm")
+    print(f"{'=' * 50}\n")
+
+    return summary
+
+
+# ── main ─────────────────────────────────────────────────────────────
+def main(year: int):
+    print(f"SEAS5 Window 1 monitoring for {year}")
+
+    # load threshold, area weights, and admin lookup from blob (dev)
+    threshold_mm = load_threshold_mm()
+    print(f"Threshold (RP6): {threshold_mm:.2f} mm")
+
+    df_areas = load_area_weights()
+    print(f"Area weights loaded for {len(df_areas)} provinces")
+
+    df_lookup = load_admin_lookup()
+    pcodes = df_lookup["adm1_pcode"].tolist()
+    print(f"Admin lookup: {len(df_lookup)} provinces, pcodes={pcodes}")
+
+    # query SEAS5 from prod postgres
+    print("Querying SEAS5 from prod database...")
+    engine = stratus.get_engine(stage="prod")
+    df_seas5 = query_seas5_mam(engine, pcodes)
+    print(f"Rows returned: {len(df_seas5)}")
+
+    # aggregate to regional MAM
+    df_regional = aggregate_regional_mam(df_seas5, df_areas, df_lookup)
+    df_regional = df_regional.loc[df_regional["year"] >= BASELINE_START_YEAR]
+    print(f"Regional MAM series: {len(df_regional)} years")
+
+    # outputs
+    out_dir = Path("outputs")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    plot_path = out_dir / "seas5_w1_monitor.png"
+    summary_path = out_dir / "seas5_w1_summary.json"
+
+    make_plot(df_regional, year, threshold_mm, plot_path)
+    summary = write_summary(df_regional, year, threshold_mm, summary_path)
+
+    # upload to blob
+    print("Uploading outputs to blob...")
+    stratus.upload_blob_data(
+        data=plot_path.read_bytes(),
+        blob_name=f"{OUTPUT_BLOB_DIR}/seas5_w1_monitor.png",
+        stage="dev",
+        container_name="projects",
+        content_type="image/png",
+    )
+    stratus.upload_blob_data(
+        data=json.dumps(summary, indent=2).encode(),
+        blob_name=f"{OUTPUT_BLOB_DIR}/seas5_w1_summary.json",
+        stage="dev",
+        container_name="projects",
+        content_type="application/json",
+    )
+    print("Upload complete.")
+
+    return summary
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="SEAS5 Window 1 monitoring (March MAM forecast)"
+    )
+    parser.add_argument(
+        "--year",
+        type=int,
+        default=datetime.now().year,
+        help="Forecast year to monitor (default: current year)",
+    )
+    args = parser.parse_args()
+    main(year=args.year)

--- a/src/monitoring_2026/w1_monitor_seas5.py
+++ b/src/monitoring_2026/w1_monitor_seas5.py
@@ -209,7 +209,7 @@ def make_plot(df_regional, current_year, threshold_mm, output_path):
     if not current_row.empty:
         val = current_row["mam_mm"].iloc[0]
         triggered = val <= threshold_mm
-        status = "TRIGGERED" if triggered else "Not triggered"
+        status = "Threshold reached" if triggered else "Threshold not reached"
         color = "#F2645A" if triggered else "#1EBFB3"
         ax.annotate(
             f"{current_year}: {val:.0f} mm\n{status}",
@@ -274,7 +274,7 @@ def write_summary(df_regional, current_year, threshold_mm, output_path):
     print(f"Summary saved: {output_path}")
 
     # also print to stdout for GHA logs
-    status = "TRIGGERED" if triggered else "NOT TRIGGERED"
+    status = "THRESHOLD REACHED" if triggered else "THRESHOLD NOT REACHED"
     print(f"\n{'=' * 50}")
     print(f"  SEAS5 W1 Result: {status}")
     print(f"  Forecast: {forecast_mm:.1f} mm")
@@ -292,7 +292,7 @@ PROD_LIST_ID = "placeholder"  # TODO: replace with Listmonk list ID
 def build_email_html(summary: dict, plot_path: Path) -> str:
     """Build HTML email body with trigger results and inline chart."""
     triggered = summary["triggered"]
-    status = "ACTIVATED" if triggered else "NOT ACTIVATED"
+    status = "THRESHOLD REACHED" if triggered else "THRESHOLD NOT REACHED"
     forecast_mm = summary["forecast_mam_mm"]
     threshold_mm = summary["threshold_mm"]
     status_color = "#F2645A" if triggered else "#1EBFB3"
@@ -310,7 +310,7 @@ Window 1 (SEAS5 seasonal precipitation forecast).
  cellspacing="0">
 <tr><td style="padding:12px 16px;background-color:{status_color};
 color:#FFFFFF;font-size:18px;font-weight:bold;text-align:center;">
-Window 1 SEAS5 trigger: {status}</td></tr>
+Window 1 SEAS5: {status}</td></tr>
 </table>
 <br>
 <table style="border-collapse:collapse;" cellpadding="8" cellspacing="0">
@@ -414,7 +414,7 @@ def main(year: int):
 
     # email notification
     triggered = summary["triggered"]
-    status = "ACTIVATED" if triggered else "NOT ACTIVATED"
+    status = "THRESHOLD REACHED" if triggered else "THRESHOLD NOT REACHED"
     year = summary["issued_year"]
 
     body_html = build_email_html(summary, plot_path)

--- a/src/monitoring_2026/w1_monitor_seas5.py
+++ b/src/monitoring_2026/w1_monitor_seas5.py
@@ -419,8 +419,8 @@ def main(year: int):
 
     body_html = build_email_html(summary, plot_path)
     subject = (
-        "Anticipatory action Afghanistan: "
-        f"Drought W1 SEAS5 forecast [{status}]"
+        "Anticipatory Action Afghanistan: "
+        f"Drought Window 1 SEAS5 forecast [{status}]"
     )
 
     campaign_id = create_campaign(

--- a/src/monitoring_2026/w1_monitor_seas5_transactional.py
+++ b/src/monitoring_2026/w1_monitor_seas5_transactional.py
@@ -1,0 +1,451 @@
+"""
+Window 1 (March) SEAS5 forecast monitoring for 2026 drought trigger.
+(Transactional email variant)
+
+Queries SEAS5 MAM seasonal forecast from the prod postgres database,
+computes the area-weighted regional aggregate for 5 northern Afghan
+provinces, and compares against the RP6 threshold.
+
+Sends email via Listmonk transactional API (not campaign).
+
+The threshold parquet is read from blob:
+    ds-aa-afg-drought/monitoring_inputs/2026/trigger_thresholds.parquet
+
+Outputs (uploaded to blob):
+    - Plot: .../monitoring_outputs/{year}/YYYYMM_seas5_w1_monitor.png
+    - Summary: .../monitoring_outputs/{year}/YYYYMM_seas5_w1_summary.json
+"""
+
+import argparse
+import base64
+import json
+from calendar import monthrange
+from datetime import UTC, datetime
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import ocha_stratus as stratus
+import pandas as pd
+from listmonk import send_transactional
+from sqlalchemy import text
+
+# ── constants ────────────────────────────────────────────────────────
+PROVINCES_AOI = ["Faryab", "Sar-e-Pul", "Jawzjan", "Balkh", "Badghis"]
+VALID_MONTHS = [3, 4, 5]
+BASELINE_START_YEAR = 1984
+
+THRESHOLD_BLOB = (
+    "ds-aa-afg-drought/monitoring_inputs/2026/trigger_thresholds.parquet"
+)
+AREA_BLOB = (
+    "ds-aa-afg-drought/raw/vector/historical_era5_land_ndjfmam_lte2025.parquet"
+)
+ADMIN_LOOKUP_BLOB = "admin_lookup.parquet"
+OUTPUT_BLOB_BASE = "ds-aa-afg-drought/monitoring_outputs"
+
+
+# ── data loading ─────────────────────────────────────────────────────
+def load_admin_lookup():
+    """Load admin lookup from blob (replicates cumulus blob_load_admin_lookup).
+
+    Returns a DataFrame filtered to AFG adm1 provinces of interest
+    with columns: adm1_name, adm1_pcode.
+    """
+    df = stratus.load_parquet_from_blob(
+        blob_name=ADMIN_LOOKUP_BLOB,
+        stage="dev",
+        container_name="polygon",
+    )
+    df.columns = df.columns.str.lower()
+    df = df.loc[
+        (df["iso3"] == "AFG")
+        & (df["adm_level"] == 1)
+        & (df["adm1_name"].isin(PROVINCES_AOI)),
+        ["adm1_name", "adm1_pcode"],
+    ].drop_duplicates()
+    return df
+
+
+def load_threshold_mm():
+    """Load the SEAS5 RP6 mm threshold from blob."""
+    df = stratus.load_parquet_from_blob(
+        blob_name=THRESHOLD_BLOB,
+        stage="dev",
+        container_name="projects",
+    )
+    row = df.loc[df["indicator"] == "seas5_mam"].iloc[0]
+    return float(row["threshold_value"])
+
+
+def load_area_weights():
+    """Load province shape areas for regional aggregation."""
+    df = stratus.load_parquet_from_blob(
+        blob_name=AREA_BLOB,
+        stage="dev",
+        container_name="projects",
+    )
+    df.columns = df.columns.str.lower().str.replace(" ", "_")
+    df = df.loc[df["adm1_name"].isin(PROVINCES_AOI)][
+        ["adm1_name", "shape_area"]
+    ].drop_duplicates()
+    return df
+
+
+def query_seas5_mam(engine, pcodes):
+    """
+    Query all March-issued SEAS5 MAM forecasts from prod postgres.
+
+    Parameters
+    ----------
+    engine : sqlalchemy engine
+    pcodes : list of str
+        Admin1 pcodes to filter (e.g. ['AF29', 'AF22', ...]).
+
+    Returns per-province, per-year rows with columns:
+        issued_date, pcode, valid_date, mean, leadtime
+    """
+    pcode_list = ", ".join(f"'{p}'" for p in pcodes)
+    valid_month_list = ", ".join(str(m) for m in VALID_MONTHS)
+
+    sql = text(f"""
+        SELECT iso3, pcode, valid_date, issued_date,
+               leadtime, mean
+        FROM seas5
+        WHERE iso3 = 'AFG'
+          AND adm_level = 1
+          AND pcode IN ({pcode_list})
+          AND EXTRACT(MONTH FROM issued_date) = 3
+          AND EXTRACT(MONTH FROM valid_date) IN ({valid_month_list})
+        ORDER BY issued_date, pcode, valid_date
+    """)
+
+    with engine.connect() as conn:
+        df = pd.read_sql(sql, conn)
+
+    return df
+
+
+# ── aggregation ──────────────────────────────────────────────────────
+def aggregate_regional_mam(df_seas5, df_areas, df_lookup):
+    """
+    Convert daily-rate forecast to MAM total (mm), then compute
+    area-weighted regional mean per issued year.
+
+    Pipeline mirrors the R feature-set creation (data-raw/16_*):
+        1. precipitation = mean × days_in_month  (daily rate → monthly)
+        2. sum across valid months per province   (→ MAM total)
+        3. weighted.mean across provinces         (→ regional)
+    """
+    df = df_seas5.copy()
+
+    # daily rate → monthly total (mm)
+    df["days"] = df["valid_date"].apply(
+        lambda d: monthrange(d.year, d.month)[1]
+    )
+    df["precip_mm"] = df["mean"] * df["days"]
+
+    # sum MAM months per province per issued_date
+    df_province = (
+        df.groupby(["issued_date", "pcode"], as_index=False)["precip_mm"]
+        .sum()
+        .rename(columns={"precip_mm": "mam_mm"})
+    )
+
+    # join pcode → adm1_name via admin lookup
+    df_province = df_province.merge(
+        df_lookup.rename(columns={"adm1_pcode": "pcode"}),
+        on="pcode",
+        how="left",
+    )
+
+    # area-weighted regional mean
+    df_province = df_province.merge(df_areas, on="adm1_name", how="left")
+
+    def _weighted_mean(g):
+        return np.average(g["mam_mm"], weights=g["shape_area"])
+
+    df_regional = (
+        df_province.groupby("issued_date", as_index=False)
+        .apply(_weighted_mean, include_groups=False)
+        .rename(columns={None: "mam_mm"})
+    )
+    df_regional["year"] = pd.to_datetime(df_regional["issued_date"]).dt.year
+
+    return df_regional
+
+
+# ── plotting ─────────────────────────────────────────────────────────
+def make_plot(df_regional, current_year, threshold_mm, output_path):
+    """
+    Bar chart of historical + current year MAM forecast vs RP6
+    threshold. Current year highlighted; bars below threshold in red.
+    """
+    df = df_regional.sort_values("year").copy()
+    df["below"] = df["mam_mm"] <= threshold_mm
+    df["is_current"] = df["year"] == current_year
+
+    fig, ax = plt.subplots(figsize=(12, 5))
+
+    colors = []
+    for _, row in df.iterrows():
+        if row["is_current"]:
+            colors.append("#1EBFB3" if not row["below"] else "#F2645A")
+        elif row["below"]:
+            colors.append("#F2645A66")
+        else:
+            colors.append("#1EBFB366")
+
+    ax.bar(df["year"], df["mam_mm"], color=colors, width=0.8)
+
+    # threshold line
+    ax.axhline(
+        threshold_mm,
+        color="#333333",
+        linestyle="--",
+        linewidth=1.5,
+        label=f"RP6 threshold ({threshold_mm:.0f} mm)",
+    )
+
+    # annotate current year
+    current_row = df.loc[df["year"] == current_year]
+    if not current_row.empty:
+        val = current_row["mam_mm"].iloc[0]
+        triggered = val <= threshold_mm
+        status = "TRIGGERED" if triggered else "Not triggered"
+        color = "#F2645A" if triggered else "#1EBFB3"
+        ax.annotate(
+            f"{current_year}: {val:.0f} mm\n{status}",
+            xy=(current_year, val),
+            xytext=(0, 15),
+            textcoords="offset points",
+            ha="center",
+            fontsize=10,
+            fontweight="bold",
+            color=color,
+            arrowprops=dict(arrowstyle="-", color=color, lw=1.5),
+        )
+
+    ax.set_xlabel("Issued year (March forecast)")
+    ax.set_ylabel("MAM precipitation forecast (mm)")
+    ax.set_title(
+        "SEAS5 MAM Forecast – Regional Aggregate\n"
+        "Afghanistan Northern Provinces Drought Trigger (Window 1)",
+        fontsize=12,
+    )
+    ax.legend(loc="upper right")
+    ax.set_ylim(bottom=0)
+
+    # only label every 5th year to avoid crowding
+    years = df["year"].values
+    ax.set_xticks(years[::5])
+    ax.set_xticklabels(years[::5], rotation=45, ha="right")
+
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Plot saved: {output_path}")
+
+
+# ── summary ──────────────────────────────────────────────────────────
+def write_summary(df_regional, current_year, threshold_mm, output_path):
+    """Write JSON summary with trigger decision."""
+    current = df_regional.loc[df_regional["year"] == current_year]
+    if current.empty:
+        raise ValueError(
+            f"No SEAS5 forecast found for {current_year}. "
+            "Has the March forecast been issued?"
+        )
+
+    forecast_mm = float(current["mam_mm"].iloc[0])
+    triggered = forecast_mm <= threshold_mm
+
+    summary = {
+        "window": "W1_SEAS5",
+        "issued_year": current_year,
+        "issued_month": 3,
+        "forecast_mam_mm": round(forecast_mm, 2),
+        "threshold_mm": round(threshold_mm, 2),
+        "threshold_rp": 6,
+        "triggered": triggered,
+        "direction": "forecast <= threshold",
+        "provinces": PROVINCES_AOI,
+        "generated_utc": datetime.now(UTC).isoformat(timespec="seconds"),
+    }
+
+    output_path.write_text(json.dumps(summary, indent=2))
+    print(f"Summary saved: {output_path}")
+
+    # also print to stdout for GHA logs
+    status = "TRIGGERED" if triggered else "NOT TRIGGERED"
+    print(f"\n{'=' * 50}")
+    print(f"  SEAS5 W1 Result: {status}")
+    print(f"  Forecast: {forecast_mm:.1f} mm")
+    print(f"  Threshold (RP6): {threshold_mm:.1f} mm")
+    print(f"{'=' * 50}\n")
+
+    return summary
+
+
+# ── email ─────────────────────────────────────────────────────────────
+TO_EMAILS = [("Zachary Arno", "zachary.arno@un.org")]
+CC_EMAILS = [("Tristan Downing", "tristan.downing@un.org")]
+
+
+def build_email_html(summary: dict, plot_path: Path) -> str:
+    """Build HTML email body with trigger results and inline chart."""
+    triggered = summary["triggered"]
+    status = "ACTIVATED" if triggered else "NOT ACTIVATED"
+    forecast_mm = summary["forecast_mam_mm"]
+    threshold_mm = summary["threshold_mm"]
+    status_color = "#F2645A" if triggered else "#1EBFB3"
+
+    plot_b64 = base64.b64encode(plot_path.read_bytes()).decode()
+
+    return f"""
+Dear colleagues,
+<br><br>
+This is an automated monitoring update for the
+<b>Anticipatory Action framework for drought in Afghanistan</b>,
+Window 1 (SEAS5 seasonal precipitation forecast).
+<br><br>
+<table style="border-collapse:collapse;width:100%;" cellpadding="0"
+ cellspacing="0">
+<tr><td style="padding:12px 16px;background-color:{status_color};
+color:#FFFFFF;font-size:18px;font-weight:bold;text-align:center;">
+Window 1 SEAS5 trigger: {status}</td></tr>
+</table>
+<br>
+<table style="border-collapse:collapse;" cellpadding="8" cellspacing="0">
+<tr>
+  <td style="border:1px solid #DDD;font-weight:bold;">
+  SEAS5 MAM forecast</td>
+  <td style="border:1px solid #DDD;">{forecast_mm:.1f} mm</td>
+</tr>
+<tr>
+  <td style="border:1px solid #DDD;font-weight:bold;">
+  RP6 threshold</td>
+  <td style="border:1px solid #DDD;">{threshold_mm:.1f} mm</td>
+</tr>
+<tr>
+  <td style="border:1px solid #DDD;font-weight:bold;">
+  Trigger direction</td>
+  <td style="border:1px solid #DDD;">
+  Forecast &le; threshold (low precipitation indicates drought risk)
+  </td>
+</tr>
+</table>
+<br>
+The chart below shows the historical and current SEAS5
+March&ndash;April&ndash;May (MAM) precipitation forecast for the five
+northern Afghan provinces (Badghis, Balkh, Faryab, Jawzjan, Sar-e-Pul),
+compared against the return-period 6 threshold.
+<br><br>
+<img src="data:image/png;base64,{plot_b64}"
+ alt="SEAS5 MAM forecast bar chart"
+ style="max-width:100%;height:auto;" />
+<br><br>
+<p style="font-size:12px;color:#666;">
+<b>About the framework:</b> Under the anticipatory action framework
+for drought in Afghanistan, Window 1 evaluates the SEAS5 seasonal
+precipitation forecast issued in March for the
+March&ndash;April&ndash;May season. An area-weighted regional aggregate
+across the five target provinces is compared against a return-period 6
+threshold. If the forecast falls at or below the threshold, the trigger
+is activated.
+</p>
+"""
+
+
+# ── main ─────────────────────────────────────────────────────────────
+def main(year: int):
+    print(f"SEAS5 Window 1 monitoring for {year}")
+
+    # load threshold, area weights, and admin lookup from blob (dev)
+    threshold_mm = load_threshold_mm()
+    print(f"Threshold (RP6): {threshold_mm:.2f} mm")
+
+    df_areas = load_area_weights()
+    print(f"Area weights loaded for {len(df_areas)} provinces")
+
+    df_lookup = load_admin_lookup()
+    pcodes = df_lookup["adm1_pcode"].tolist()
+    print(f"Admin lookup: {len(df_lookup)} provinces, pcodes={pcodes}")
+
+    # query SEAS5 from prod postgres
+    print("Querying SEAS5 from prod database...")
+    engine = stratus.get_engine(stage="prod")
+    df_seas5 = query_seas5_mam(engine, pcodes)
+    print(f"Rows returned: {len(df_seas5)}")
+
+    # aggregate to regional MAM
+    df_regional = aggregate_regional_mam(df_seas5, df_areas, df_lookup)
+    df_regional = df_regional.loc[df_regional["year"] >= BASELINE_START_YEAR]
+    print(f"Regional MAM series: {len(df_regional)} years")
+
+    # outputs
+    prefix = f"{year}03"
+    out_dir = Path("outputs")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    plot_name = f"{prefix}_seas5_w1_monitor.png"
+    summary_name = f"{prefix}_seas5_w1_summary.json"
+    plot_path = out_dir / plot_name
+    summary_path = out_dir / summary_name
+
+    make_plot(df_regional, year, threshold_mm, plot_path)
+    summary = write_summary(df_regional, year, threshold_mm, summary_path)
+
+    # upload to blob
+    blob_dir = f"{OUTPUT_BLOB_BASE}/{year}"
+    print(f"Uploading outputs to blob: {blob_dir}/...")
+    stratus.upload_blob_data(
+        data=plot_path.read_bytes(),
+        blob_name=f"{blob_dir}/{plot_name}",
+        stage="dev",
+        container_name="projects",
+        content_type="image/png",
+    )
+    stratus.upload_blob_data(
+        data=json.dumps(summary, indent=2).encode(),
+        blob_name=f"{blob_dir}/{summary_name}",
+        stage="dev",
+        container_name="projects",
+        content_type="application/json",
+    )
+    print("Upload complete.")
+
+    # email notification (transactional)
+    triggered = summary["triggered"]
+    status = "ACTIVATED" if triggered else "NOT ACTIVATED"
+
+    body_html = build_email_html(summary, plot_path)
+    subject = (
+        "Anticipatory action Afghanistan: "
+        f"Drought W1 SEAS5 forecast [{status}]"
+    )
+
+    print(f"Sending transactional email to {TO_EMAILS}...")
+    send_transactional(
+        to_emails=TO_EMAILS,
+        cc_emails=CC_EMAILS,
+        subject=subject,
+        data={"content": body_html},
+    )
+    print("Transactional email sent.")
+
+    return summary
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="SEAS5 Window 1 monitoring (March MAM forecast)"
+    )
+    parser.add_argument(
+        "--year",
+        type=int,
+        default=datetime.now().year,
+        help="Forecast year to monitor (default: current year)",
+    )
+    args = parser.parse_args()
+    main(year=args.year)

--- a/src/monitoring_2026/w1_monitor_seas5_transactional.py
+++ b/src/monitoring_2026/w1_monitor_seas5_transactional.py
@@ -33,7 +33,7 @@ from sqlalchemy import text
 # ── constants ────────────────────────────────────────────────────────
 PROVINCES_AOI = ["Faryab", "Sar-e-Pul", "Jawzjan", "Balkh", "Badghis"]
 VALID_MONTHS = [3, 4, 5]
-BASELINE_START_YEAR = 1984
+BASELINE_START_YEAR = 1991
 
 THRESHOLD_BLOB = (
     "ds-aa-afg-drought/monitoring_inputs/2026/trigger_thresholds.parquet"
@@ -358,7 +358,7 @@ is activated.
 
 
 # ── main ─────────────────────────────────────────────────────────────
-def main(year: int):
+def main(year: int, test: bool = False):
     print(f"SEAS5 Window 1 monitoring for {year}")
 
     # load threshold, area weights, and admin lookup from blob (dev)
@@ -424,6 +424,8 @@ def main(year: int):
         "Anticipatory action Afghanistan: "
         f"Drought W1 SEAS5 forecast [{status}]"
     )
+    if test:
+        subject = f"[test] {subject}"
 
     print(f"Sending transactional email to {TO_EMAILS}...")
     send_transactional(
@@ -447,5 +449,10 @@ if __name__ == "__main__":
         default=datetime.now().year,
         help="Forecast year to monitor (default: current year)",
     )
+    parser.add_argument(
+        "--test",
+        action="store_true",
+        help="Add [test] prefix to subject line",
+    )
     args = parser.parse_args()
-    main(year=args.year)
+    main(year=args.year, test=args.test)

--- a/src/monitoring_2026/w1_monitor_seas5_transactional.py
+++ b/src/monitoring_2026/w1_monitor_seas5_transactional.py
@@ -471,8 +471,8 @@ def main(year: int, test: bool = False, email_group: str = "core_developer"):
 
     body_html = build_email_html(summary, plot_path)
     subject = (
-        "Anticipatory action Afghanistan: "
-        f"Drought W1 SEAS5 forecast [{status}]"
+        "Anticipatory Action Afghanistan: "
+        f"Drought Window 1 SEAS5 forecast [{status}]"
     )
     if test:
         subject = f"[test] {subject}"

--- a/src/monitoring_2026/w1_monitor_seas5_transactional.py
+++ b/src/monitoring_2026/w1_monitor_seas5_transactional.py
@@ -212,7 +212,7 @@ def make_plot(df_regional, current_year, threshold_mm, output_path):
     if not current_row.empty:
         val = current_row["mam_mm"].iloc[0]
         triggered = val <= threshold_mm
-        status = "TRIGGERED" if triggered else "Not triggered"
+        status = "Threshold reached" if triggered else "Threshold not reached"
         color = "#F2645A" if triggered else "#1EBFB3"
         ax.annotate(
             f"{current_year}: {val:.0f} mm\n{status}",
@@ -277,7 +277,7 @@ def write_summary(df_regional, current_year, threshold_mm, output_path):
     print(f"Summary saved: {output_path}")
 
     # also print to stdout for GHA logs
-    status = "TRIGGERED" if triggered else "NOT TRIGGERED"
+    status = "THRESHOLD REACHED" if triggered else "THRESHOLD NOT REACHED"
     print(f"\n{'=' * 50}")
     print(f"  SEAS5 W1 Result: {status}")
     print(f"  Forecast: {forecast_mm:.1f} mm")
@@ -295,7 +295,7 @@ CC_EMAILS = [("Tristan Downing", "tristan.downing@un.org")]
 def build_email_html(summary: dict, plot_path: Path) -> str:
     """Build HTML email body with trigger results and inline chart."""
     triggered = summary["triggered"]
-    status = "ACTIVATED" if triggered else "NOT ACTIVATED"
+    status = "THRESHOLD REACHED" if triggered else "THRESHOLD NOT REACHED"
     forecast_mm = summary["forecast_mam_mm"]
     threshold_mm = summary["threshold_mm"]
     status_color = "#F2645A" if triggered else "#1EBFB3"
@@ -313,7 +313,7 @@ Window 1 (SEAS5 seasonal precipitation forecast).
  cellspacing="0">
 <tr><td style="padding:12px 16px;background-color:{status_color};
 color:#FFFFFF;font-size:18px;font-weight:bold;text-align:center;">
-Window 1 SEAS5 trigger: {status}</td></tr>
+Window 1 SEAS5: {status}</td></tr>
 </table>
 <br>
 <table style="border-collapse:collapse;" cellpadding="8" cellspacing="0">
@@ -417,7 +417,7 @@ def main(year: int, test: bool = False):
 
     # email notification (transactional)
     triggered = summary["triggered"]
-    status = "ACTIVATED" if triggered else "NOT ACTIVATED"
+    status = "THRESHOLD REACHED" if triggered else "THRESHOLD NOT REACHED"
 
     body_html = build_email_html(summary, plot_path)
     subject = (

--- a/src/monitoring_2026/w1_monitor_seas5_transactional.py
+++ b/src/monitoring_2026/w1_monitor_seas5_transactional.py
@@ -19,6 +19,7 @@ Outputs (uploaded to blob):
 import argparse
 import base64
 import json
+import re
 from calendar import monthrange
 from datetime import UTC, datetime
 from pathlib import Path
@@ -43,6 +44,9 @@ AREA_BLOB = (
 )
 ADMIN_LOOKUP_BLOB = "admin_lookup.parquet"
 OUTPUT_BLOB_BASE = "ds-aa-afg-drought/monitoring_outputs"
+DISTRIBUTION_LIST_BLOB = (
+    "ds-aa-afg-drought/monitoring_inputs/2026/distribution_list.csv"
+)
 
 
 # ── data loading ─────────────────────────────────────────────────────
@@ -288,8 +292,48 @@ def write_summary(df_regional, current_year, threshold_mm, output_path):
 
 
 # ── email ─────────────────────────────────────────────────────────────
-TO_EMAILS = [("Zachary Arno", "zachary.arno@un.org")]
-CC_EMAILS = [("Tristan Downing", "tristan.downing@un.org")]
+def load_distribution_list(group: str = "full_list"):
+    """Load email distribution list from blob and split into to/cc lists.
+
+    Parameters
+    ----------
+    group : str
+        Column name in the CSV to filter on (e.g. 'core_developer',
+        'developers', 'internal_chd', 'full_list').
+
+    Returns
+    -------
+    to_emails, cc_emails : tuple of list[tuple[str, str]]
+        Each entry is (name, email). Name may be empty string.
+    """
+    df = stratus.load_csv_from_blob(
+        blob_name=DISTRIBUTION_LIST_BLOB,
+        stage="dev",
+        container_name="projects",
+    )
+    df = df.loc[df[group].fillna(False).astype(bool)]
+
+    # validate email addresses
+    email_re = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+    invalid = df.loc[
+        ~df["email"].str.match(email_re, na=False), "email"
+    ].tolist()
+    if invalid:
+        print(
+            f"WARNING: invalid email addresses in distribution list: {invalid}"
+        )
+
+    df = df.loc[df["email"].str.match(email_re, na=False)]
+
+    def _to_tuples(sub):
+        return [
+            ("" if pd.isna(row.get("name")) else row["name"], row["email"])
+            for _, row in sub.iterrows()
+        ]
+
+    to_emails = _to_tuples(df.loc[df["to_cc"] == "to"])
+    cc_emails = _to_tuples(df.loc[df["to_cc"] == "cc"])
+    return to_emails, cc_emails
 
 
 def build_email_html(summary: dict, plot_path: Path) -> str:
@@ -351,14 +395,14 @@ for drought in Afghanistan, Window 1 evaluates the SEAS5 seasonal
 precipitation forecast issued in March for the
 March&ndash;April&ndash;May season. An area-weighted regional aggregate
 across the five target provinces is compared against a return-period 6
-threshold. If the forecast falls at or below the threshold, the trigger
-is activated.
+threshold. If the forecast falls at or below the threshold, the
+threshold is considered reached.
 </p>
 """
 
 
 # ── main ─────────────────────────────────────────────────────────────
-def main(year: int, test: bool = False):
+def main(year: int, test: bool = False, email_group: str = "core_developer"):
     print(f"SEAS5 Window 1 monitoring for {year}")
 
     # load threshold, area weights, and admin lookup from blob (dev)
@@ -419,6 +463,12 @@ def main(year: int, test: bool = False):
     triggered = summary["triggered"]
     status = "THRESHOLD REACHED" if triggered else "THRESHOLD NOT REACHED"
 
+    to_emails, cc_emails = load_distribution_list(group=email_group)
+    print(
+        f"Distribution list ({email_group}): "
+        f"{len(to_emails)} to, {len(cc_emails)} cc"
+    )
+
     body_html = build_email_html(summary, plot_path)
     subject = (
         "Anticipatory action Afghanistan: "
@@ -427,10 +477,10 @@ def main(year: int, test: bool = False):
     if test:
         subject = f"[test] {subject}"
 
-    print(f"Sending transactional email to {TO_EMAILS}...")
+    print(f"Sending transactional email to {[e for _, e in to_emails]}...")
     send_transactional(
-        to_emails=TO_EMAILS,
-        cc_emails=CC_EMAILS,
+        to_emails=to_emails,
+        cc_emails=cc_emails,
         subject=subject,
         data={"content": body_html},
     )
@@ -454,5 +504,17 @@ if __name__ == "__main__":
         action="store_true",
         help="Add [test] prefix to subject line",
     )
+    parser.add_argument(
+        "--email-group",
+        type=str,
+        default="core_developer",
+        choices=[
+            "core_developer",
+            "developers",
+            "internal_chd",
+            "full_list",
+        ],
+        help="Distribution list group to send to (default: core_developer)",
+    )
     args = parser.parse_args()
-    main(year=args.year, test=args.test)
+    main(year=args.year, test=args.test, email_group=args.email_group)


### PR DESCRIPTION
## Note to reviewer:

The only things for review in the branch is the monitoring workflow (`.github/workflows/` , `src/monitoring_2026/`. There were some diffs caught in the book that I guess were not committed in prev branches, but not consequential. If you want we could merge this into 2026-model for a full review together.

I've tested this locally using 2025 data and it seemed to work fine (2026 mar forecast not published yet). The whole automation system might be a bit overkill as this specific this workflow run will only really be used one time, but i wanted to test the LISTMONK stuff out anyways. I still would need to switch this to the transactional modality for production.... i think at the end of the idea the ideal situation for this run would just be to run it as workflow dispatch system where we run it 1x to get an internal preview - and then as long as it looks good run again as another dispatch in PROD mode.

Then can follow this same design for April activation moment and then thats it!

## Summary
- Adds Listmonk email notification to W1 SEAS5 monitoring pipeline
- `listmonk.py`: thin API wrapper (create + send campaign), matching `ds-fms-tc-outlook` pattern
- `w1_monitor_seas5.py`: inline HTML email with trigger status banner, forecast vs threshold table, and embedded bar chart
- Updated GHA workflow with Listmonk secrets/vars
- Added `requests` dependency

## Test plan
- [x] Tested locally with `--year 2025`, email received on test list (list 16)
- [x] Merge #32 first to register workflow on main
- [ ] Run workflow via manual dispatch against this branch
- [ ] Replace placeholder PROD_LIST_ID when ready for stakeholder distribution